### PR TITLE
Add support for worktree binary detection and usage

### DIFF
--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -1,13 +1,14 @@
-use std::fs;
 use std::path::PathBuf;
+use std::{fs, path::Path};
 
-use zed_extension_api::{self as zed, LanguageServerId, Result, settings::LspSettings};
+use zed_extension_api::{self as zed, LanguageServerId, Result, serde_json, settings::LspSettings};
 
 struct TsGoExtension {
     cached_binary_path: Option<String>,
     cached_version: Option<String>,
 }
 
+const WORKTREE_SERVER_PATH: &str = "node_modules/@typescript/native-preview/bin/tsgo.js";
 const PACKAGE_NAME: &str = "@typescript/native-preview";
 
 #[derive(Debug, Default)]
@@ -84,6 +85,20 @@ impl TsGoExtension {
         }
 
         Ok(binary_path)
+    }
+
+    fn worktree_tsgo_exists(&self, worktree: &zed::Worktree) -> bool {
+        let package_json = worktree
+            .read_text_file("package.json")
+            .unwrap_or(String::from(r#"{}"#));
+
+        let package_json: Option<serde_json::Value> =
+            serde_json::from_str(package_json.as_str()).ok();
+
+        package_json.is_some_and(|f| {
+            !f["dependencies"][PACKAGE_NAME].is_null()
+                || !f["devDependencies"][PACKAGE_NAME].is_null()
+        })
     }
 
     fn binary_exists(&self) -> bool {
@@ -174,16 +189,37 @@ impl zed::Extension for TsGoExtension {
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
         let lsp_settings = LspSettings::for_worktree("tsgo", worktree).ok();
-        
+
         let env = lsp_settings
             .as_ref()
             .and_then(|s| s.binary.as_ref())
-            .and_then(|binary| binary.env.clone());
+            .and_then(|binary| binary.env.clone())
+            .into_iter()
+            .flat_map(|env| env.into_iter())
+            .collect();
 
         let settings = lsp_settings
             .as_ref()
             .map(|s| TsGoSettings::from_lsp_settings(s))
             .unwrap_or_default();
+
+        let mut args = vec!["--lsp".to_string(), "--stdio".to_string()];
+
+        if self.worktree_tsgo_exists(worktree) {
+            let server_path = Path::new(worktree.root_path().as_str())
+                .join(WORKTREE_SERVER_PATH)
+                .to_string_lossy()
+                .to_string();
+
+            let mut node_args = vec![server_path];
+            node_args.append(&mut args);
+
+            return Ok(zed::Command {
+                command: zed::node_binary_path()?,
+                args: node_args,
+                env,
+            });
+        }
 
         let package_version = settings.package_version.as_deref();
         let executable_path = self.binary_path(language_server_id, package_version)?;
@@ -194,8 +230,8 @@ impl zed::Extension for TsGoExtension {
                 .join(executable_path)
                 .to_string_lossy()
                 .into_owned(),
-            args: vec!["--lsp".into(), "--stdio".into()],
-            env: env.into_iter().flat_map(|env| env.into_iter()).collect(),
+            args,
+            env,
         })
     }
 


### PR DESCRIPTION
Resolves #37

> [!NOTE]  
> I realize that third-party contributions are often more of a burden than a boon, so I just minimally got this working for my own purposes.  I'm happy to adjust this so it aligns with the team's norms and standards, just let me know.
> 
> I did not use AI in any way in the development of this PR.

This PR adds basic support to both detect and then use tsgo installed in the current project's worktree, using a similar approach to the biome extension here:
https://github.com/biomejs/biome-zed/blob/main/src/biome.rs#L157-L171

## Test plan

I tested this basically by importing into my editor and running against my current project:

1. I ensured that the tsgo lsp was indeed running against the correct path in the `dev: language server logs` pane.  And I confirmed that tsgo was providing lsp autocompletions via the dev pane's RPC messages log and within an open typescript file.

```
* Binary: LanguageServerBinary {
    path: "/run/current-system/sw/bin/node",
    arguments: [
        "/Users/cole/Code/Sophia/node_modules/@typescript/native-preview/bin/tsgo.js",
        "--lsp",
        "--stdio",
    ],

```

2. I ran in a vanilla project without tsgo installed in npm, and confirmed that the autocomplete was working in a test file and that the tsgo binary being leveraged was the system version installed by the extension:

```
* Binary: LanguageServerBinary {
    path: "/Users/cole/Library/Application Support/Zed/extensions/work/tsgo/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo",
    arguments: [
        "--lsp",
        "--stdio",
    ],

```

