### PR TITLE
Use native `typescript` v7 package instead of `@typescript/native-preview`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # tsgo: Native TypeScript Compiler Integration for Zed
 
-This extension integrates `tsgo`, Microsoft's native Go-based TypeScript compiler, into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
+This extension integrates TypeScript v7's native Go-based compiler and language server into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
 
-## 🚀 Why `tsgo`?
+## 🚀 Why the native compiler?
 
-Microsoft is transitioning the TypeScript compiler from its JavaScript implementation to a native version written in Go, aiming for significant performance improvements:
+With TypeScript 7, Microsoft shipped the TypeScript compiler as a native version written in Go, with significant performance improvements:
 
 - **Faster Compilation**: Achieves up to 10x speed improvements in large projects.
 - **Reduced Memory Usage**: Optimized memory handling in native execution.
@@ -25,8 +25,6 @@ Microsoft is transitioning the TypeScript compiler from its JavaScript implement
 2. Search for `tsgo` and install the extension.
 
 ## ⚙️ Configuration
-
-_Note_: `tsgo` is currently in preview and may not support all features of the standard `tsc` compiler.
 
 ### Basic Setup
 
@@ -65,14 +63,14 @@ To do that with `vtsls`, use:
 
 #### Specifying a Package Version
 
-By default, the extension installs and uses the latest version of the `@typescript/native-preview` [npm package](https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions). To pin a specific version:
+By default, the extension installs and uses the latest version of the `typescript` [npm package](https://www.npmjs.com/package/typescript?activeTab=versions). To pin a specific version (must be >= 7.0.0, older versions have no native language server):
 
 ```json
 {
   "lsp": {
     "tsgo": {
       "settings": {
-        "package_version": "7.0.0-dev.20251029.1"
+        "package_version": "7.0.2"
       }
     }
   }
@@ -84,7 +82,3 @@ This is useful for:
 - Ensuring consistent behavior across the project
 - Testing specific versions
 - Avoiding automatic updates that might introduce issues
-
-## 🧪 Status
-
-This extension is in early development stages. While it offers significant performance benefits, some features may be incomplete or unstable. Contributions and feedback are welcome to improve its functionality.

--- a/README.md
+++ b/README.md
@@ -22,40 +22,60 @@ With TypeScript 7, Microsoft shipped the TypeScript compiler as a native version
 ## 🛠 Installation
 
 1. Open Zed's Extensions page.
-2. Search for `tsgo` and install the extension.
+2. Search for `TypeScript Language Server` and install the extension.
 
 ## ⚙️ Configuration
 
 ### Basic Setup
 
-Enable `tsgo` in your Zed settings:
+Enable `typescript-ls` in your Zed settings:
 
 ```jsonc
 {
-  "languages": {
-    "TypeScript": {
-      "language_servers": ["tsgo", "!vtsls", "!typescript-language-server", "..."],
+    "languages": {
+        "TypeScript": {
+            "language_servers": [
+                "typescript-ls",
+                "!vtsls",
+                "!typescript-language-server",
+                "...",
+            ],
+        },
+        "TSX": {
+            "language_servers": [
+                "typescript-ls",
+                "!vtsls",
+                "!typescript-language-server",
+                "...",
+            ],
+        },
     },
-    "TSX": {
-      "language_servers": ["tsgo", "!vtsls", "!typescript-language-server", "..."],
-    },
-  },
 }
 ```
 
-You can also use `tsgo` in tandem with other language servers (e.g. `typescript-language-server` or `vtsls`). Zed will use `tsgo` for features it supports and fallback to the next language server in the list for unsupported features.
+You can also use `typescript-ls` in tandem with other language servers (e.g. `typescript-language-server` or `vtsls`). Zed will use `typescript-ls` for features it supports and fallback to the next language server in the list for unsupported features.
 To do that with `vtsls`, use:
 
 ```jsonc
 {
-  "languages": {
-    "TypeScript": {
-      "language_servers": ["tsgo", "vtsls", "!typescript-language-server", "..."],
+    "languages": {
+        "TypeScript": {
+            "language_servers": [
+                "typescript-ls",
+                "vtsls",
+                "!typescript-language-server",
+                "...",
+            ],
+        },
+        "TSX": {
+            "language_servers": [
+                "typescript-ls",
+                "vtsls",
+                "!typescript-language-server",
+                "...",
+            ],
+        },
     },
-    "TSX": {
-      "language_servers": ["tsgo", "vtsls", "!typescript-language-server", "..."],
-    },
-  },
 }
 ```
 
@@ -67,13 +87,13 @@ By default, the extension installs and uses the latest version of the `typescrip
 
 ```json
 {
-  "lsp": {
-    "tsgo": {
-      "settings": {
-        "package_version": "7.0.2"
-      }
+    "lsp": {
+        "typescript-ls": {
+            "settings": {
+                "package_version": "7.0.2"
+            }
+        }
     }
-  }
 }
 ```
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "tsgo"
 name = "tsgo"
-description = "Native implementation of TypeScript compiler."
+description = "TypeScript v7's native compiler and language server."
 version = "0.0.5"
 schema_version = 1
 authors = ["Zed Industries <hello@zed.dev>"]
@@ -9,7 +9,7 @@ repository = "https://github.com/zed-extensions/tsgo"
 
 [language_servers.tsgo]
 name = "tsgo"
-# TSGo determines ScriptKind from LSP languageId (textDocument/didOpen).
+# The native TypeScript server determines ScriptKind from LSP languageId (textDocument/didOpen).
 # ScriptKind enum definition: https://github.com/microsoft/typescript-go/blob/main/internal/parser/parser.go (search for "type ScriptKind")
 # Panic location (initializeState): https://github.com/microsoft/typescript-go/blob/main/internal/parser/parser.go#L210
 # Maps Zed's language names to standard LSP languageId values:

--- a/extension.toml
+++ b/extension.toml
@@ -1,5 +1,5 @@
 id = "tsgo"
-name = "tsgo"
+name = "TypeScript Language Server"
 description = "TypeScript v7's native compiler and language server."
 version = "0.0.5"
 schema_version = 1
@@ -7,8 +7,8 @@ authors = ["Zed Industries <hello@zed.dev>"]
 repository = "https://github.com/zed-extensions/tsgo"
 
 
-[language_servers.tsgo]
-name = "tsgo"
+[language_servers.typescript-ls]
+name = "TypeScript LS"
 # The native TypeScript server determines ScriptKind from LSP languageId (textDocument/didOpen).
 # ScriptKind enum definition: https://github.com/microsoft/typescript-go/blob/main/internal/parser/parser.go (search for "type ScriptKind")
 # Panic location (initializeState): https://github.com/microsoft/typescript-go/blob/main/internal/parser/parser.go#L210

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -8,7 +8,7 @@ struct TsGoExtension {
     cached_version: Option<String>,
 }
 
-const PACKAGE_NAME: &str = "@typescript/native-preview";
+const PACKAGE_NAME: &str = "typescript";
 
 #[derive(Debug, Default)]
 struct TsGoSettings {
@@ -49,7 +49,7 @@ impl TsGoExtension {
             zed::Architecture::X8664 => "x64",
         };
 
-        Ok(format!("@typescript/native-preview-{}-{}", os, arch))
+        Ok(format!("@typescript/typescript-{}-{}", os, arch))
     }
 
     fn get_native_binary_path() -> Result<PathBuf> {
@@ -60,7 +60,7 @@ impl TsGoExtension {
 
         if !package_path.exists() {
             return Err(format!(
-                "Platform package {} not found at {}. Make sure the correct platform-specific package is installed.",
+                "Platform package {} not found at {}. Make sure the correct platform-specific package is installed (a pinned package_version must be >= 7.0.0; older typescript versions have no native binary).",
                 platform_package,
                 package_path.display()
             ));
@@ -68,8 +68,8 @@ impl TsGoExtension {
 
         let (platform, _) = zed::current_platform();
         let binary_name = match platform {
-            zed::Os::Windows => "tsgo.exe",
-            _ => "tsgo",
+            zed::Os::Windows => "tsc.exe",
+            _ => "tsc",
         };
 
         let binary_path = package_path.join("lib").join(binary_name);

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -1,7 +1,9 @@
+use std::cell::OnceCell;
 use std::fs;
 use std::path::PathBuf;
 
-use zed_extension_api::{self as zed, LanguageServerId, Result, settings::LspSettings};
+use zed_extension_api::serde_json::Value;
+use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree, settings::LspSettings};
 
 struct TsGoExtension {
     cached_binary_path: Option<String>,
@@ -9,6 +11,8 @@ struct TsGoExtension {
 }
 
 const PACKAGE_NAME: &str = "typescript";
+/// LSP ID previously used before TypeScript 7 was released
+const FALLBACK_KEY: &str = "tsgo";
 
 #[derive(Debug, Default)]
 struct TsGoSettings {
@@ -16,11 +20,9 @@ struct TsGoSettings {
 }
 
 impl TsGoSettings {
-    fn from_lsp_settings(settings: &LspSettings) -> Self {
+    fn from_lsp_settings(settings: &Value) -> Self {
         let package_version = settings
-            .settings
-            .as_ref()
-            .and_then(|s| s.get("package_version"))
+            .get("package_version")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
@@ -60,9 +62,10 @@ impl TsGoExtension {
 
         if !package_path.exists() {
             return Err(format!(
-                "Platform package {} not found at {}. Make sure the correct platform-specific package is installed (a pinned package_version must be >= 7.0.0; older typescript versions have no native binary).",
-                platform_package,
-                package_path.display()
+                "Platform package {platform_package} not found at {package_path}. \
+                Make sure the correct platform-specific package is installed \
+                (a pinned package_version must be >= 7.0.0; older typescript versions have no native binary).",
+                package_path = package_path.display()
             ));
         }
 
@@ -150,7 +153,7 @@ impl TsGoExtension {
         package_version: Option<&str>,
     ) -> Result<String> {
         // Return cached path if we have it and binary still exists
-        if let Some(ref cached_path) = self.cached_binary_path
+        if let Some(cached_path) = self.cached_binary_path.as_ref()
             && fs::metadata(cached_path).is_ok_and(|stat| stat.is_file())
         {
             return Ok(cached_path.clone());
@@ -179,17 +182,21 @@ impl zed::Extension for TsGoExtension {
         language_server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
-        let lsp_settings = LspSettings::for_worktree("tsgo", worktree).ok();
-
-        let env = lsp_settings
-            .as_ref()
-            .and_then(|s| s.binary.as_ref())
-            .and_then(|binary| binary.env.clone());
+        let lsp_settings =
+            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
 
         let settings = lsp_settings
             .as_ref()
-            .map(TsGoSettings::from_lsp_settings)
+            .and_then(|settings| {
+                settings
+                    .get_setting(|s| s.settings.as_ref())
+                    .map(TsGoSettings::from_lsp_settings)
+            })
             .unwrap_or_default();
+
+        let env = lsp_settings
+            .and_then(|lsp_settings| lsp_settings.into_setting(|s| s.binary))
+            .and_then(|binary| binary.env);
 
         let package_version = settings.package_version.as_deref();
         let executable_path = self.binary_path(language_server_id, package_version)?;
@@ -210,9 +217,8 @@ impl zed::Extension for TsGoExtension {
         server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
-        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
-            .ok()
-            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+        let settings = LspSettingsWithFallback::for_worktree(server_id, FALLBACK_KEY, worktree)?
+            .into_setting(|lsp_settings| lsp_settings.initialization_options)
             .unwrap_or_default();
         Ok(Some(settings))
     }
@@ -222,11 +228,56 @@ impl zed::Extension for TsGoExtension {
         server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
-        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
-            .ok()
-            .and_then(|lsp_settings| lsp_settings.settings.clone())
+        let settings = LspSettingsWithFallback::for_worktree(server_id, FALLBACK_KEY, worktree)?
+            .into_setting(|lsp_settings| lsp_settings.settings)
             .unwrap_or_default();
         Ok(Some(settings))
+    }
+}
+
+struct LspSettingsWithFallback<'a> {
+    settings: LspSettings,
+    fallback_id: &'static str,
+    fallback_settings: OnceCell<Option<LspSettings>>,
+    worktree: &'a Worktree,
+}
+
+impl<'a> LspSettingsWithFallback<'a> {
+    fn for_worktree(
+        server_id: &LanguageServerId,
+        fallback_id: &'static str,
+        worktree: &'a Worktree,
+    ) -> zed_extension_api::Result<Self> {
+        LspSettings::for_worktree(server_id.as_ref(), worktree).map(|settings| Self {
+            settings,
+            fallback_id,
+            fallback_settings: OnceCell::new(),
+            worktree,
+        })
+    }
+
+    fn get_setting<F, R>(&self, f: F) -> Option<&R>
+    where
+        F: Fn(&LspSettings) -> Option<&R>,
+    {
+        f(&self.settings).or_else(|| {
+            self.fallback_settings
+                .get_or_init(|| LspSettings::for_worktree(self.fallback_id, self.worktree).ok())
+                .as_ref()
+                .and_then(f)
+        })
+    }
+
+    fn into_setting<F, R>(self, f: F) -> Option<R>
+    where
+        F: Fn(LspSettings) -> Option<R>,
+    {
+        f(self.settings).or_else(|| {
+            let _ = self
+                .fallback_settings
+                .get_or_init(|| LspSettings::for_worktree(self.fallback_id, self.worktree).ok());
+            self.fallback_settings.into_inner().flatten().and_then(f)
+        })
     }
 }
 


### PR DESCRIPTION
TypeScript v7 has been released which gives native LSP capabilities to the regular `tsc` binary included in the npm `typescript` package.

```sh
tsc --lsp --stdio
```

As far as I can tell, the LSP from `tsgo` and v7's `tsc` work identically, so this extension needs no changes other than swapping `@typescript/native-preview` for `typescript` and `tsgo` for `tsc`.