### PR TITLE
Update to TypeScript 7.0: use standard `typescript` npm package instead of `@typescript/native-preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tsgo"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tsgo"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # tsgo: Native TypeScript Compiler Integration for Zed
 
-This extension integrates `tsgo`, Microsoft's native Go-based TypeScript compiler, into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
+This extension integrates the native, Go-based TypeScript compiler and language server into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
 
-## 🚀 Why `tsgo`?
+With the release of **TypeScript 7.0**, this native implementation has graduated from the `@typescript/native-preview` preview package into the standard [`typescript`](https://www.npmjs.com/package/typescript) package on npm. This extension installs and runs that native `tsc`/language server directly.
 
-Microsoft is transitioning the TypeScript compiler from its JavaScript implementation to a native version written in Go, aiming for significant performance improvements:
+## 🚀 Why the native compiler?
+
+TypeScript 7.0 ports the compiler from its JavaScript implementation to a native version written in Go, delivering significant performance improvements:
 
 - **Faster Compilation**: Achieves up to 10x speed improvements in large projects.
 - **Reduced Memory Usage**: Optimized memory handling in native execution.
@@ -26,7 +28,7 @@ Microsoft is transitioning the TypeScript compiler from its JavaScript implement
 
 ## ⚙️ Configuration
 
-_Note_: `tsgo` is currently in preview and may not support all features of the standard `tsc` compiler.
+_Note_: While TypeScript 7.0 is now stable, some tools (e.g. `typescript-eslint`) still require the TypeScript 6.0 API, since a new native compiler API isn't expected until TypeScript 7.1. This extension only integrates the compiler and language server, so it isn't affected by that limitation.
 
 ### Basic Setup
 
@@ -65,14 +67,14 @@ To do that with `vtsls`, use:
 
 #### Specifying a Package Version
 
-By default, the extension installs and uses the latest version of the `@typescript/native-preview` [npm package](https://www.npmjs.com/package/@typescript/native-preview?activeTab=versions). To pin a specific version:
+By default, the extension installs and uses the latest version of the [`typescript`](https://www.npmjs.com/package/typescript?activeTab=versions) npm package. To pin a specific version:
 
 ```json
 {
   "lsp": {
     "tsgo": {
       "settings": {
-        "package_version": "7.0.0-dev.20251029.1"
+        "package_version": "7.0.2"
       }
     }
   }
@@ -84,6 +86,8 @@ This is useful for:
 - Ensuring consistent behavior across the project
 - Testing specific versions
 - Avoiding automatic updates that might introduce issues
+
+Nightly builds are now published under the `next` dist-tag of the standard `typescript` package (replacing the old `@typescript/native-preview` nightlies). You can pin to one by using its exact dev version, e.g. `"package_version": "7.1.0-dev.<date>.<n>"` — check the [version list](https://www.npmjs.com/package/typescript?activeTab=versions) for the latest `next` release.
 
 ## 🧪 Status
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This extension integrates the native, Go-based TypeScript compiler and language server into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
 
-With the release of **TypeScript 7.0**, this native implementation has graduated from the `@typescript/native-preview` preview package into the standard [`typescript`](https://www.npmjs.com/package/typescript) package on npm. This extension installs and runs that native `tsc`/language server directly.
-
 ## 🚀 Why the native compiler?
 
 TypeScript 7.0 ports the compiler from its JavaScript implementation to a native version written in Go, delivering significant performance improvements:
@@ -87,7 +85,7 @@ This is useful for:
 - Testing specific versions
 - Avoiding automatic updates that might introduce issues
 
-Nightly builds are now published under the `next` dist-tag of the standard `typescript` package (replacing the old `@typescript/native-preview` nightlies). You can pin to one by using its exact dev version, e.g. `"package_version": "7.1.0-dev.<date>.<n>"` — check the [version list](https://www.npmjs.com/package/typescript?activeTab=versions) for the latest `next` release.
+You can also pin to a nightly build by using a version published under the `next` dist-tag, e.g. `"package_version": "7.1.0-dev.20260710.1"` (nightly builds are published to the stand
 
 ## 🧪 Status
 

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "tsgo"
 name = "tsgo"
 description = "Native implementation of TypeScript compiler."
-version = "0.0.5"
+version = "0.0.6"
 schema_version = 1
 authors = ["Zed Industries <hello@zed.dev>"]
 repository = "https://github.com/zed-extensions/tsgo"

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -8,7 +8,7 @@ struct TsGoExtension {
     cached_version: Option<String>,
 }
 
-const PACKAGE_NAME: &str = "@typescript/native-preview";
+const PACKAGE_NAME: &str = "typescript";
 
 #[derive(Debug, Default)]
 struct TsGoSettings {
@@ -49,7 +49,7 @@ impl TsGoExtension {
             zed::Architecture::X8664 => "x64",
         };
 
-        Ok(format!("@typescript/native-preview-{}-{}", os, arch))
+        Ok(format!("@typescript/typescript-{}-{}", os, arch))
     }
 
     fn get_native_binary_path() -> Result<PathBuf> {
@@ -68,8 +68,8 @@ impl TsGoExtension {
 
         let (platform, _) = zed::current_platform();
         let binary_name = match platform {
-            zed::Os::Windows => "tsgo.exe",
-            _ => "tsgo",
+            zed::Os::Windows => "tsc.exe",
+            _ => "tsc",
         };
 
         let binary_path = package_path.join("lib").join(binary_name);


### PR DESCRIPTION
## Description

TypeScript 7.0 has officially shipped. As part of this release, the native Go-based compiler has graduated out of the `@typescript/native-preview` preview package and into the standard [`typescript`](https://www.npmjs.com/package/typescript) npm package. The old preview package will no longer receive updates, so this extension needs to switch over to keep working.

### Changes

- **`src/tsgo.rs`**
  - Install/resolve `typescript` instead of `@typescript/native-preview`.
  - Resolve platform-specific packages as `@typescript/typescript-{os}-{arch}` (e.g. `@typescript/typescript-darwin-arm64`) instead of `@typescript/native-preview-{os}-{arch}`.
  - Locate the native binary at `lib/tsc` (`lib/tsc.exe` on Windows) instead of `lib/tsgo` (`lib/tsgo.exe`), matching the renamed binary shipped by the new package.
- **`README.md`**
  - Explain the migration from `@typescript/native-preview` to `typescript`.
  - Drop the "currently in preview" language now that TS 7.0 is stable, and note the remaining TS 6.0 API caveat for tools like `typescript-eslint` (unaffected by this extension, since it only wires up the compiler/language server).
  - Update the `package_version` pinning example to a real released version (`7.0.2`), and note that nightly builds now live under the `next` dist-tag of the standard `typescript` package.
- **`extension.toml`, `Cargo.toml`, `Cargo.lock`**
  - Bump extension version `0.0.5` to `0.0.6`.

### Verification

- Confirmed the new package layout directly against the npm registry: `typescript@7.0.2`'s optional platform dependencies (e.g. `@typescript/typescript-darwin-arm64`, `@typescript/typescript-win32-x64`) ship the native binary at `lib/tsc` / `lib/tsc.exe`.
- Confirmed the old `@typescript/native-preview` package (latest nightly `7.0.0-dev.20260707.2`) uses the previous naming/layout being replaced here.
- `cargo build --target wasm32-wasip2` compiles cleanly with these changes.

### Notes for reviewers

- The extension id/name (`tsgo`) and the `tsgo` LSP settings key are unchanged, so existing user settings (`lsp.tsgo.settings...`) continue to work, only the underlying npm package and binary name changed.
- No functional change to the `--lsp --stdio` invocation; TS 7.0's language server is the same one previously shipped under `native-preview`, just renamed.
