### PR TITLE
Resolve project-local TypeScript installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,94 @@
-# tsgo: Native TypeScript Compiler Integration for Zed
+# tsgo: TypeScript 7 language server for Zed
 
-This extension integrates TypeScript v7's native Go-based compiler and language server into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
+This extension runs TypeScript 7's native, Go-based language server in Zed for JavaScript, JSX,
+TypeScript, and TSX.
 
-## 🚀 Why the native compiler?
+## Installation
 
-With TypeScript 7, Microsoft shipped the TypeScript compiler as a native version written in Go, with significant performance improvements:
+Open Zed's Extensions page, search for `TypeScript Language Server`, and install the extension.
 
-- **Faster Compilation**: Achieves up to 10x speed improvements in large projects.
-- **Reduced Memory Usage**: Optimized memory handling in native execution.
-- **Improved Editor Performance**: Faster IntelliSense and language services.
-- **Scalability**: Better handling of large codebases.
-
-> _Example Benchmarks_:
->
-> - **VS Code**: 77.8s → 7.5s (10.4x speedup)
-> - **Playwright**: 11.1s → 1.1s (10.1x speedup)
-> - **TypeORM**: 17.5s → 1.3s (13.5x speedup)
->
-> _Source: [Microsoft Developer Blog](https://devblogs.microsoft.com/typescript/typescript-native-port/)_
-
-## 🛠 Installation
-
-1. Open Zed's Extensions page.
-2. Search for `TypeScript Language Server` and install the extension.
-
-## ⚙️ Configuration
-
-### Basic Setup
-
-Enable `typescript-ls` in your Zed settings:
+The server id is `typescript-ls`. To make it the primary TypeScript server:
 
 ```jsonc
 {
-    "languages": {
-        "TypeScript": {
-            "language_servers": [
-                "typescript-ls",
-                "!vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
-        "TSX": {
-            "language_servers": [
-                "typescript-ls",
-                "!vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
+  "languages": {
+    "JavaScript": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
     },
+    "JSX": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    },
+    "TypeScript": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    },
+    "TSX": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    }
+  }
 }
 ```
 
-You can also use `typescript-ls` in tandem with other language servers (e.g. `typescript-language-server` or `vtsls`). Zed will use `typescript-ls` for features it supports and fallback to the next language server in the list for unsupported features.
-To do that with `vtsls`, use:
+You can also keep another server later in the list for features the native server does not yet
+support:
 
 ```jsonc
 {
-    "languages": {
-        "TypeScript": {
-            "language_servers": [
-                "typescript-ls",
-                "vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
-        "TSX": {
-            "language_servers": [
-                "typescript-ls",
-                "vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["typescript-ls", "vtsls", "!typescript-language-server", "..."]
     },
+    "TSX": {
+      "language_servers": ["typescript-ls", "vtsls", "!typescript-language-server", "..."]
+    }
+  }
 }
 ```
 
-### Advanced Configuration
+## How the server runs
 
-#### Specifying a Package Version
+TypeScript 7's language server is a native executable in the platform-specific
+`@typescript/typescript-<platform>-<arch>` npm packages, launched in LSP mode:
 
-By default, the extension installs and uses the latest version of the `typescript` [npm package](https://www.npmjs.com/package/typescript?activeTab=versions). To pin a specific version (must be >= 7.0.0, older versions have no native language server):
+```sh
+tsc --lsp --stdio
+```
+
+The extension executes that native binary directly when it can locate it next to the resolved
+`typescript` package. Otherwise it launches the package's `bin/tsc` Node shim, which uses
+Microsoft's own package resolution and covers pnpm and unusual install layouts. The fallback uses
+the worktree's `node` (including Volta/fnm shims) when available, or Zed's bundled Node.
+
+## TypeScript package resolution
+
+The extension resolves the TypeScript 7+ package in this order:
+
+1. A TypeScript dependency in the worktree root's `package.json`. The extension checks
+   `dependencies`, `devDependencies`, and `peerDependencies`, including `npm:` aliases under any
+   dependency name. Declarations that clearly select TypeScript 6 are skipped; when installed
+   package metadata is visible through Zed's worktree API, its version is checked as well.
+2. A managed `typescript` install in the extension's working directory.
+
+This supports Microsoft's TypeScript 6/7 side-by-side setup, for example:
 
 ```json
 {
-    "lsp": {
-        "typescript-ls": {
-            "settings": {
-                "package_version": "7.0.2"
-            }
-        }
-    }
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7",
+    "typescript": "npm:@typescript/typescript6@^6"
+  }
 }
 ```
 
-This is useful for:
+The TypeScript 7 alias is selected and the TypeScript 6 compatibility package is ignored.
 
-- Ensuring consistent behavior across the project
-- Testing specific versions
-- Avoiding automatic updates that might introduce issues
+TypeScript 6 and older cannot run the native LSP and are rejected. Use Zed's built-in TypeScript
+support for those versions.
+
+## Development
+
+Install Rust with `rustup`, then run `zed: install dev extension` and select this directory.
+
+After source changes, rebuild the extension from the Extensions page. Run Zed with
+`zed --foreground` or use `zed: open log` to inspect extension and language-server errors.
+
+<!-- markdownlint-disable-file MD013 -->

--- a/extension.toml
+++ b/extension.toml
@@ -17,3 +17,7 @@ name = "TypeScript LS"
 #   javascript -> ScriptKindJS, javascriptreact -> ScriptKindJSX
 language_ids = { TypeScript = "typescript", TSX = "typescriptreact", JavaScript = "javascript", JSX = "javascriptreact" }
 languages = ["TypeScript", "TSX", "JavaScript", "JSX"]
+
+[[capabilities]]
+kind = "npm:install"
+package = "typescript"

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -1,3 +1,5 @@
+mod typescript_package;
+
 use std::cell::OnceCell;
 use std::fs;
 use std::path::PathBuf;
@@ -167,6 +169,67 @@ impl TsGoExtension {
 
         Ok(binary_path.to_string_lossy().to_string())
     }
+
+    fn build_language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<zed::Command> {
+        let lsp_settings =
+            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
+
+        let settings = lsp_settings
+            .as_ref()
+            .and_then(|settings| {
+                settings
+                    .get_setting(|settings| settings.settings.as_ref())
+                    .map(TsGoSettings::from_lsp_settings)
+            })
+            .unwrap_or_default();
+
+        let binary_env = lsp_settings
+            .and_then(|settings| settings.into_setting(|settings| settings.binary))
+            .and_then(|binary| binary.env);
+        let env = server_environment(worktree, binary_env);
+        let arguments = vec!["--lsp".into(), "--stdio".into()];
+
+        if let Some(package_directory) =
+            typescript_package::find_local_typescript_package_dir(worktree)
+        {
+            if let Some(native) =
+                typescript_package::find_native_server_binary(worktree, &package_directory)
+            {
+                return Ok(zed::Command {
+                    command: native,
+                    args: arguments,
+                    env,
+                });
+            }
+
+            let node = worktree
+                .which("node")
+                .map(Ok)
+                .unwrap_or_else(zed::node_binary_path)?;
+            let shim = typescript_package::node_shim_path(worktree, &package_directory)?;
+            return Ok(zed::Command {
+                command: node,
+                args: std::iter::once(shim).chain(arguments).collect(),
+                env,
+            });
+        }
+
+        let executable_path =
+            self.binary_path(language_server_id, settings.package_version.as_deref())?;
+        Ok(zed::Command {
+            command: std::env::current_dir()
+                .map_err(|error| error.to_string())?
+                .join(executable_path)
+                .to_string_lossy()
+                .into_owned(),
+            args: arguments,
+            env,
+        })
+    }
 }
 
 impl zed::Extension for TsGoExtension {
@@ -182,34 +245,22 @@ impl zed::Extension for TsGoExtension {
         language_server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
-        let lsp_settings =
-            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
-
-        let settings = lsp_settings
-            .as_ref()
-            .and_then(|settings| {
-                settings
-                    .get_setting(|s| s.settings.as_ref())
-                    .map(TsGoSettings::from_lsp_settings)
-            })
-            .unwrap_or_default();
-
-        let env = lsp_settings
-            .and_then(|lsp_settings| lsp_settings.into_setting(|s| s.binary))
-            .and_then(|binary| binary.env);
-
-        let package_version = settings.package_version.as_deref();
-        let executable_path = self.binary_path(language_server_id, package_version)?;
-
-        Ok(zed::Command {
-            command: std::env::current_dir()
-                .map_err(|e| e.to_string())?
-                .join(executable_path)
-                .to_string_lossy()
-                .into_owned(),
-            args: vec!["--lsp".into(), "--stdio".into()],
-            env: env.into_iter().flat_map(|env| env.into_iter()).collect(),
-        })
+        match self.build_language_server_command(language_server_id, worktree) {
+            Ok(command) => {
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::None,
+                );
+                Ok(command)
+            }
+            Err(error) => {
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::Failed(error.clone()),
+                );
+                Err(error)
+            }
+        }
     }
 
     fn language_server_initialization_options(
@@ -233,6 +284,20 @@ impl zed::Extension for TsGoExtension {
             .unwrap_or_default();
         Ok(Some(settings))
     }
+}
+
+fn server_environment(
+    worktree: &Worktree,
+    binary_env: Option<std::collections::HashMap<String, String>>,
+) -> Vec<(String, String)> {
+    let mut env = worktree.shell_env();
+    if let Some(binary_env) = binary_env {
+        for (key, value) in binary_env {
+            env.retain(|(existing_key, _)| *existing_key != key);
+            env.push((key, value));
+        }
+    }
+    env
 }
 
 struct LspSettingsWithFallback<'a> {

--- a/src/typescript_package.rs
+++ b/src/typescript_package.rs
@@ -1,0 +1,501 @@
+use zed_extension_api::{self as zed, Result};
+
+pub const TYPESCRIPT_PACKAGE: &str = "typescript";
+
+/// Finds a usable project-local TypeScript 7+ package by scanning the root
+/// package manifest. npm aliases may use any dependency key, but their target
+/// package must be `typescript`.
+pub fn find_local_typescript_package_dir(worktree: &zed::Worktree) -> Option<String> {
+    let content = worktree.read_text_file("package.json").ok()?;
+    let pkg: zed::serde_json::Value = zed::serde_json::from_str(&content).ok()?;
+
+    let root = worktree
+        .root_path()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+
+    find_typescript_dependency(&pkg, &root, |key, _spec, _directory| {
+        let package_json_path = format!("node_modules/{key}/package.json");
+        match worktree.read_text_file(&package_json_path) {
+            Ok(package_json) => {
+                typescript_version_from_package_json(&package_json, &package_json_path)
+                    .and_then(|version| ensure_typescript_7_or_newer(&version))
+                    .is_ok()
+            }
+            // Excluded directories such as node_modules are not always exposed
+            // through Worktree::read_text_file. The manifest declaration was
+            // already checked above, so let Microsoft's launcher resolve it.
+            Err(_) => true,
+        }
+    })
+}
+
+fn find_typescript_dependency(
+    pkg: &zed::serde_json::Value,
+    root: &str,
+    mut package_is_usable: impl FnMut(&str, &str, &str) -> bool,
+) -> Option<String> {
+    for section in ["dependencies", "devDependencies", "peerDependencies"] {
+        let Some(dependencies) = pkg.get(section).and_then(|value| value.as_object()) else {
+            continue;
+        };
+
+        for (key, value) in dependencies {
+            let Some(spec) = value.as_str() else {
+                continue;
+            };
+            if dependency_package_name(key, spec) != Some(TYPESCRIPT_PACKAGE) {
+                continue;
+            }
+            if !declared_spec_may_resolve_to_typescript_7(spec) {
+                continue;
+            }
+
+            let dir = format!("{root}/node_modules/{key}");
+            if package_is_usable(key, spec, &dir) {
+                return Some(dir);
+            }
+        }
+    }
+
+    None
+}
+
+fn dependency_package_name<'a>(key: &'a str, spec: &'a str) -> Option<&'a str> {
+    let spec = spec.trim();
+    let Some(alias) = spec.strip_prefix("npm:") else {
+        return Some(key);
+    };
+
+    let version_separator = if let Some(scoped_alias) = alias.strip_prefix('@') {
+        scoped_alias.rfind('@').map(|position| position + 1)
+    } else {
+        alias.rfind('@')
+    };
+    let package_name = version_separator.map_or(alias, |position| &alias[..position]);
+    (!package_name.is_empty()).then_some(package_name)
+}
+
+/// Rejects declarations that clearly select TypeScript 6 while allowing tags,
+/// broader ranges, and non-registry specs whose installed version cannot be
+/// known from `package.json` alone.
+fn declared_spec_may_resolve_to_typescript_7(spec: &str) -> bool {
+    let spec = dependency_version_spec(spec).trim();
+    if spec.is_empty() {
+        return true;
+    }
+
+    if let Some((_, upper_bound)) = spec.split_once('<') {
+        let upper_bound = upper_bound.trim();
+        let is_inclusive = upper_bound.starts_with('=');
+        let upper_bound = upper_bound.trim_start_matches('=').trim();
+        if leading_major(upper_bound)
+            .is_some_and(|major| major < 7 || (major == 7 && !is_inclusive))
+        {
+            return false;
+        }
+    }
+
+    let bounded_from_major = spec
+        .trim_start_matches(['v', '^', '~', '=', ' '])
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit())
+        && !spec.starts_with('>')
+        && !spec.contains("||");
+    if bounded_from_major {
+        return leading_major(spec).is_none_or(|major| major >= 7);
+    }
+
+    true
+}
+
+fn dependency_version_spec(spec: &str) -> &str {
+    let spec = spec.trim();
+    let Some(alias) = spec.strip_prefix("npm:") else {
+        return spec;
+    };
+
+    let separator = if let Some(scoped_alias) = alias.strip_prefix('@') {
+        scoped_alias.rfind('@').map(|position| position + 1)
+    } else {
+        alias.rfind('@')
+    };
+    separator.map_or("", |position| &alias[position + 1..])
+}
+
+fn leading_major(spec: &str) -> Option<u64> {
+    let digits: String = spec
+        .chars()
+        .skip_while(|character| !character.is_ascii_digit())
+        .take_while(|character| character.is_ascii_digit())
+        .collect();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+fn typescript_version_from_package_json(content: &str, path: &str) -> Result<String> {
+    let pkg: zed::serde_json::Value =
+        zed::serde_json::from_str(content).map_err(|error| format!("invalid {path}: {error}"))?;
+    pkg.get("version")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("no version in {path}"))
+}
+
+/// Locates the native `tsc` executable in the platform package next to (or
+/// inside) the resolved TypeScript package. Callers fall back to Microsoft's
+/// Node launcher when an install layout cannot be resolved directly.
+pub fn find_native_server_binary(worktree: &zed::Worktree, package_dir: &str) -> Option<String> {
+    if let Some(relative_directory) = worktree_relative_directory(worktree, package_dir) {
+        let relative_binary = find_worktree_native_server_binary(worktree, &relative_directory)?;
+        return Some(absolute_worktree_path(worktree, &relative_binary));
+    }
+
+    let (platform_package, executable) = platform_package_and_executable()?;
+    let candidates = [
+        format!("{package_dir}/lib/{executable}"),
+        format!("{package_dir}/../{platform_package}/lib/{executable}"),
+        format!("{package_dir}/node_modules/{platform_package}/lib/{executable}"),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file()))
+}
+
+fn find_worktree_native_server_binary(
+    worktree: &zed::Worktree,
+    relative_package_directory: &str,
+) -> Option<String> {
+    let (platform_package, executable) = platform_package_and_executable()?;
+    let candidates = [
+        relative_package_directory.to_string(),
+        format!("node_modules/{platform_package}"),
+        format!("{relative_package_directory}/node_modules/{platform_package}"),
+    ];
+
+    candidates.into_iter().find_map(|candidate| {
+        let package_json_path = format!("{candidate}/package.json");
+        let package_json = worktree.read_text_file(&package_json_path).ok()?;
+        let package: zed::serde_json::Value = zed::serde_json::from_str(&package_json).ok()?;
+        let package_name = package.get("name").and_then(|name| name.as_str());
+
+        let is_platform_package =
+            candidate != relative_package_directory || package_name == Some(&platform_package);
+        is_platform_package.then(|| format!("{candidate}/lib/{executable}"))
+    })
+}
+
+fn platform_package_and_executable() -> Option<(String, &'static str)> {
+    let (os, arch) = zed::current_platform();
+    let platform = match os {
+        zed::Os::Mac => "darwin",
+        zed::Os::Linux => "linux",
+        zed::Os::Windows => "win32",
+    };
+    let arch = match arch {
+        zed::Architecture::Aarch64 => "arm64",
+        zed::Architecture::X8664 => "x64",
+        zed::Architecture::X86 => return None,
+    };
+    let exe = match os {
+        zed::Os::Windows => "tsc.exe",
+        _ => "tsc",
+    };
+
+    Some((format!("@typescript/typescript-{platform}-{arch}"), exe))
+}
+
+pub fn node_shim_path(worktree: &zed::Worktree, package_dir: &str) -> Result<String> {
+    let shim = format!("{package_dir}/bin/tsc");
+    let is_in_worktree = worktree_relative_directory(worktree, package_dir).is_some();
+    let exists =
+        is_in_worktree || std::fs::metadata(&shim).is_ok_and(|metadata| metadata.is_file());
+
+    if exists || !path_is_in_extension_work_directory(package_dir) {
+        Ok(shim)
+    } else {
+        Err(format!(
+            "TypeScript package at `{package_dir}` has no native server binary for this platform and no `bin/tsc` launcher"
+        ))
+    }
+}
+
+fn normalized_worktree_root(worktree: &zed::Worktree) -> String {
+    let root = worktree.root_path().replace('\\', "/");
+    if root == "/" {
+        root
+    } else {
+        root.trim_end_matches('/').to_string()
+    }
+}
+
+fn absolute_worktree_path(worktree: &zed::Worktree, relative_path: &str) -> String {
+    let root = normalized_worktree_root(worktree);
+    if root == "/" {
+        format!("/{relative_path}")
+    } else {
+        format!("{root}/{relative_path}")
+    }
+}
+
+fn worktree_relative_directory(worktree: &zed::Worktree, directory: &str) -> Option<String> {
+    let root = normalized_worktree_root(worktree);
+    let directory = directory.replace('\\', "/");
+    if directory == root {
+        return Some(String::new());
+    }
+
+    let prefix = if root == "/" {
+        root
+    } else {
+        format!("{root}/")
+    };
+    if matches!(zed::current_platform().0, zed::Os::Windows) {
+        directory
+            .to_ascii_lowercase()
+            .strip_prefix(&prefix.to_ascii_lowercase())
+            .map(|relative| {
+                let start = directory.len() - relative.len();
+                directory[start..].to_string()
+            })
+    } else {
+        directory.strip_prefix(&prefix).map(|path| path.to_string())
+    }
+}
+
+fn path_is_in_extension_work_directory(path: &str) -> bool {
+    let Ok(current_directory) = std::env::current_dir() else {
+        return false;
+    };
+    let current_directory = current_directory
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    let path = path.replace('\\', "/");
+    path == current_directory || path.starts_with(&format!("{current_directory}/"))
+}
+
+pub fn ensure_typescript_7_or_newer(version: &str) -> Result<()> {
+    let version_without_prefix = version.strip_prefix('v').unwrap_or(version);
+    let major_part = version_without_prefix
+        .split(|character: char| !character.is_ascii_digit())
+        .next()
+        .unwrap_or("");
+    if major_part.is_empty() {
+        return Err(format!("invalid TypeScript version `{version}`"));
+    }
+    let major: u64 = major_part
+        .parse()
+        .map_err(|_| format!("invalid TypeScript version `{version}`"))?;
+    if major < 7 {
+        return Err(format!(
+            "TypeScript LSP requires TypeScript 7 or newer, got `{version}`"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+
+    struct TestProject {
+        root: PathBuf,
+    }
+
+    impl TestProject {
+        fn new(name: &str) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+            let root = std::env::temp_dir().join(format!(
+                "tsgo-{name}-{}-{}",
+                std::process::id(),
+                NEXT_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&root).expect("create test project directory");
+            Self { root }
+        }
+
+        fn add_package(&self, key: &str, version: &str, has_launcher: bool) -> String {
+            let package_dir = self.root.join("node_modules").join(key);
+            std::fs::create_dir_all(&package_dir).expect("create test package directory");
+            std::fs::write(
+                package_dir.join("package.json"),
+                format!(r#"{{"version":"{version}"}}"#),
+            )
+            .expect("write test package.json");
+
+            if has_launcher {
+                let bin_dir = package_dir.join("bin");
+                std::fs::create_dir_all(&bin_dir).expect("create test package bin directory");
+                std::fs::write(bin_dir.join("tsc"), "").expect("write test tsc launcher");
+            }
+
+            package_dir
+                .to_string_lossy()
+                .into_owned()
+                .replace('\\', "/")
+        }
+
+        fn root(&self) -> String {
+            self.root.to_string_lossy().into_owned().replace('\\', "/")
+        }
+    }
+
+    impl Drop for TestProject {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn test_package_is_usable(_key: &str, _spec: &str, directory: &str) -> bool {
+        let package_json_path = format!("{directory}/package.json");
+        let Ok(package_json) = std::fs::read_to_string(&package_json_path) else {
+            return false;
+        };
+        let Ok(version) = typescript_version_from_package_json(&package_json, &package_json_path)
+        else {
+            return false;
+        };
+
+        ensure_typescript_7_or_newer(&version).is_ok()
+            && std::fs::metadata(format!("{directory}/bin/tsc"))
+                .is_ok_and(|metadata| metadata.is_file())
+    }
+
+    #[test]
+    fn parses_dependency_package_names() {
+        let cases = [
+            (("typescript", "^7.0.2"), Some("typescript")),
+            (("typescript", "^8.0.0"), Some("typescript")),
+            (
+                ("@typescript/native", "npm:typescript@^7.0.2"),
+                Some("typescript"),
+            ),
+            (("whatever", " npm:typescript@next "), Some("typescript")),
+            (("foo", "^7.2.0"), Some("foo")),
+            (("foo", "npm:bar@7.0.0"), Some("bar")),
+            (
+                ("typescript", "npm:@typescript/typescript6@^6.0.2"),
+                Some("@typescript/typescript6"),
+            ),
+            (("foo", "npm:@scope/package@next"), Some("@scope/package")),
+            (("foo", "npm:@scope/package"), Some("@scope/package")),
+            (("foo", "npm:"), None),
+        ];
+
+        for ((key, spec), expected) in cases {
+            assert_eq!(dependency_package_name(key, spec), expected);
+        }
+    }
+
+    #[test]
+    fn identifies_declarations_that_can_select_typescript_7() {
+        for spec in [
+            "7.0.2",
+            "^7",
+            "~7.1",
+            "next",
+            "latest",
+            ">=6",
+            ">=6 <8",
+            "<=7",
+            "^6 || ^7",
+            "workspace:^6",
+            "npm:typescript@^7",
+        ] {
+            assert!(
+                declared_spec_may_resolve_to_typescript_7(spec),
+                "{spec} should be accepted"
+            );
+        }
+
+        for spec in [
+            "6.0.2",
+            "^6",
+            "~6.1",
+            "6.x",
+            "<7",
+            "<=6",
+            ">=6 <7",
+            "npm:typescript@^6",
+        ] {
+            assert!(
+                !declared_spec_may_resolve_to_typescript_7(spec),
+                "{spec} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn local_resolution_ignores_unrelated_packages_and_accepts_typescript_8() {
+        let project = TestProject::new("package-identity");
+        project.add_package("foo", "7.2.0", true);
+        let typescript_dir = project.add_package("typescript", "8.0.0", true);
+        let manifest = zed::serde_json::json!({
+            "dependencies": {
+                "foo": "^7.2.0",
+                "typescript": "^8.0.0"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(typescript_dir)
+        );
+    }
+
+    #[test]
+    fn local_resolution_supports_side_by_side_aliases() {
+        let project = TestProject::new("side-by-side-aliases");
+        let native_dir = project.add_package("@typescript/native", "7.0.2", true);
+        project.add_package("typescript", "6.0.2", true);
+        let manifest = zed::serde_json::json!({
+            "devDependencies": {
+                "@typescript/native": "npm:typescript@^7.0.2",
+                "typescript": "npm:@typescript/typescript6@^6.0.2"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(native_dir)
+        );
+    }
+
+    #[test]
+    fn local_resolution_continues_after_an_outdated_alias() {
+        let project = TestProject::new("continue-after-outdated");
+        project.add_package("a-typescript", "6.0.2", true);
+        let usable_dir = project.add_package("z-typescript", "7.0.2", true);
+        let manifest = zed::serde_json::json!({
+            "dependencies": {
+                "a-typescript": "npm:typescript@6.0.2",
+                "z-typescript": "npm:typescript@7.0.2"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(usable_dir)
+        );
+    }
+
+    #[test]
+    fn validates_supported_typescript_versions() {
+        assert!(ensure_typescript_7_or_newer("7.0.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("7.1.0-beta.1").is_ok());
+        assert!(ensure_typescript_7_or_newer("10.0.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("v7.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("6.9.9").is_err());
+        assert!(ensure_typescript_7_or_newer("foo").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Prefer a TypeScript 7+ dependency from the worktree root before using the extension-managed install.
- Support `dependencies`, `devDependencies`, and `peerDependencies`, including `npm:` aliases used by Microsoft's TypeScript 6/7 side-by-side setup.
- Launch the platform-native compiler directly when its package layout is visible, otherwise use Microsoft's `bin/tsc` launcher with the worktree's Node or Zed's bundled Node.
- Validate package identity and TypeScript major versions when package metadata is available, while preserving the existing managed fallback.
- Report installation failures through Zed's language-server status and declare the scoped `npm:install` capability.

## Motivation

Projects should use the TypeScript version they declare instead of silently running an unrelated extension-managed version. This is especially important for projects that install TypeScript 7 under an npm alias while retaining the TypeScript 6 compatibility package under the `typescript` name.

Closes #37.

## Stack

This is the first independently mergeable layer of a four-PR series:

1. zed-extensions/tsgo#61 — project-local TypeScript resolution ([99fbf5b](https://github.com/zed-extensions/tsgo/pull/61/commits/99fbf5bdd6c095338a4c314c953018b614160e70))
2. [zed-extensions/tsgo#62](https://github.com/zed-extensions/tsgo/pull/62) — explicit and managed package selection ([902ba4d](https://github.com/zed-extensions/tsgo/pull/62/commits/902ba4da14bc250ae8ba06a55f47a891b213b76f))
3. [zed-extensions/tsgo#63](https://github.com/zed-extensions/tsgo/pull/63) — server runtime controls ([307be82](https://github.com/zed-extensions/tsgo/pull/63/commits/307be82b0247242744a5e1131f105bc3fadba03c))
4. [zed-extensions/tsgo#64](https://github.com/zed-extensions/tsgo/pull/64) — language-server configuration and completion labels ([1354401](https://github.com/zed-extensions/tsgo/pull/64/commits/1354401fc48370a9a028bd233563cf43f4facb88))

Merge order is #61 → #62 → #63 → #64. Each follow-up currently includes the preceding layers in its GitHub diff because all four PRs target upstream `main`; the commit shown above is the focused incremental change for that layer.

The final layer isolates the general configuration pipeline so its limited overlap with the open inlay-hints/code-lens work in #54 can be resolved independently.

## Compatibility

- The `typescript-ls` language-server id is unchanged.
- Existing `lsp.tsgo` fallback settings and `package_version` behavior are preserved.
- Projects without a usable local TypeScript 7+ dependency continue using the managed install.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets` (6 tests)
- `markdownlint-cli2 README.md`
- `tombi lint extension.toml Cargo.toml`
- `git diff --check`