### PR TITLE
Add explicit and managed TypeScript selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,94 @@
-# tsgo: Native TypeScript Compiler Integration for Zed
+# tsgo: TypeScript 7 language server for Zed
 
-This extension integrates TypeScript v7's native Go-based compiler and language server into the Zed editor, delivering enhanced performance and efficiency for TypeScript development.
+This extension runs TypeScript 7's native, Go-based language server in Zed for JavaScript, JSX,
+TypeScript, and TSX.
 
-## 🚀 Why the native compiler?
+## Installation
 
-With TypeScript 7, Microsoft shipped the TypeScript compiler as a native version written in Go, with significant performance improvements:
+Open Zed's Extensions page, search for `TypeScript Language Server`, and install the extension.
 
-- **Faster Compilation**: Achieves up to 10x speed improvements in large projects.
-- **Reduced Memory Usage**: Optimized memory handling in native execution.
-- **Improved Editor Performance**: Faster IntelliSense and language services.
-- **Scalability**: Better handling of large codebases.
-
-> _Example Benchmarks_:
->
-> - **VS Code**: 77.8s → 7.5s (10.4x speedup)
-> - **Playwright**: 11.1s → 1.1s (10.1x speedup)
-> - **TypeORM**: 17.5s → 1.3s (13.5x speedup)
->
-> _Source: [Microsoft Developer Blog](https://devblogs.microsoft.com/typescript/typescript-native-port/)_
-
-## 🛠 Installation
-
-1. Open Zed's Extensions page.
-2. Search for `TypeScript Language Server` and install the extension.
-
-## ⚙️ Configuration
-
-### Basic Setup
-
-Enable `typescript-ls` in your Zed settings:
+The server id is `typescript-ls`. To make it the primary TypeScript server:
 
 ```jsonc
 {
-    "languages": {
-        "TypeScript": {
-            "language_servers": [
-                "typescript-ls",
-                "!vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
-        "TSX": {
-            "language_servers": [
-                "typescript-ls",
-                "!vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
+  "languages": {
+    "JavaScript": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
     },
+    "JSX": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    },
+    "TypeScript": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    },
+    "TSX": {
+      "language_servers": ["typescript-ls", "!vtsls", "!typescript-language-server", "..."]
+    }
+  }
 }
 ```
 
-You can also use `typescript-ls` in tandem with other language servers (e.g. `typescript-language-server` or `vtsls`). Zed will use `typescript-ls` for features it supports and fallback to the next language server in the list for unsupported features.
-To do that with `vtsls`, use:
+You can also keep another server later in the list for features the native server does not yet
+support:
 
 ```jsonc
 {
-    "languages": {
-        "TypeScript": {
-            "language_servers": [
-                "typescript-ls",
-                "vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
-        "TSX": {
-            "language_servers": [
-                "typescript-ls",
-                "vtsls",
-                "!typescript-language-server",
-                "...",
-            ],
-        },
+  "languages": {
+    "TypeScript": {
+      "language_servers": ["typescript-ls", "vtsls", "!typescript-language-server", "..."]
     },
+    "TSX": {
+      "language_servers": ["typescript-ls", "vtsls", "!typescript-language-server", "..."]
+    }
+  }
 }
 ```
 
-### Advanced Configuration
+## How the server runs
 
-#### Specifying a Package Version
+TypeScript 7's language server is a native executable in the platform-specific
+`@typescript/typescript-<platform>-<arch>` npm packages, launched in LSP mode:
 
-By default, the extension installs and uses the latest version of the `typescript` [npm package](https://www.npmjs.com/package/typescript?activeTab=versions). To pin a specific version (must be >= 7.0.0, older versions have no native language server):
+```sh
+tsc --lsp --stdio
+```
+
+The extension executes that native binary directly when it can locate it next to the resolved
+`typescript` package. Otherwise it launches the package's `bin/tsc` Node shim, which uses
+Microsoft's own package resolution and covers pnpm and unusual install layouts. The fallback uses
+the worktree's `node` (including Volta/fnm shims) when available, or Zed's bundled Node.
+
+## TypeScript package resolution
+
+The extension resolves the TypeScript 7+ package in this order:
+
+1. A TypeScript dependency in the worktree root's `package.json`. The extension checks
+   `dependencies`, `devDependencies`, and `peerDependencies`, including `npm:` aliases under any
+   dependency name. Declarations that clearly select TypeScript 6 are skipped; when installed
+   package metadata is visible through Zed's worktree API, its version is checked as well.
+2. A managed `typescript` install in the extension's working directory.
+
+This supports Microsoft's TypeScript 6/7 side-by-side setup, for example:
 
 ```json
 {
-    "lsp": {
-        "typescript-ls": {
-            "settings": {
-                "package_version": "7.0.2"
-            }
-        }
-    }
+  "devDependencies": {
+    "@typescript/native": "npm:typescript@^7",
+    "typescript": "npm:@typescript/typescript6@^6"
+  }
 }
 ```
 
-This is useful for:
+The TypeScript 7 alias is selected and the TypeScript 6 compatibility package is ignored.
 
-- Ensuring consistent behavior across the project
-- Testing specific versions
-- Avoiding automatic updates that might introduce issues
+TypeScript 6 and older cannot run the native LSP and are rejected. Use Zed's built-in TypeScript
+support for those versions.
+
+## Development
+
+Install Rust with `rustup`, then run `zed: install dev extension` and select this directory.
+
+After source changes, rebuild the extension from the Extensions page. Run Zed with
+`zed --foreground` or use `zed: open log` to inspect extension and language-server errors.
+
+<!-- markdownlint-disable-file MD013 -->

--- a/README.md
+++ b/README.md
@@ -62,11 +62,15 @@ the worktree's `node` (including Volta/fnm shims) when available, or Zed's bundl
 
 The extension resolves the TypeScript 7+ package in this order:
 
-1. A TypeScript dependency in the worktree root's `package.json`. The extension checks
+1. `tsdk.path`, when set. It accepts a package root, the package's `lib` directory (the VS Code
+   `typescript.tsdk` convention), a `bin/tsc` path, or a platform package containing the native
+   executable. The version is checked when Zed exposes the package metadata to the extension;
+   otherwise the package's own launcher validates it at startup.
+2. A TypeScript dependency in the worktree root's `package.json`. The extension checks
    `dependencies`, `devDependencies`, and `peerDependencies`, including `npm:` aliases under any
    dependency name. Declarations that clearly select TypeScript 6 are skipped; when installed
    package metadata is visible through Zed's worktree API, its version is checked as well.
-2. A managed `typescript` install in the extension's working directory.
+3. A managed `typescript` install in the extension's working directory.
 
 This supports Microsoft's TypeScript 6/7 side-by-side setup, for example:
 
@@ -83,6 +87,41 @@ The TypeScript 7 alias is selected and the TypeScript 6 compatibility package is
 
 TypeScript 6 and older cannot run the native LSP and are rejected. Use Zed's built-in TypeScript
 support for those versions.
+
+## Managed install version
+
+Managed installs use the latest stable TypeScript release by default. These settings live under
+`lsp.typescript-ls.settings`:
+
+| Setting | Install behavior |
+| --- | --- |
+| `package_version` | Existing setting for any npm version spec, such as `7.0.2`, `next`, or `^7`. |
+| `version` | Alias for `package_version`; `package_version` wins when both are present. |
+| `updateChannel: "latest"` | Install the latest stable `typescript` package. |
+| `updateChannel: "next"` | Install `typescript@next`, TypeScript's nightly channel. |
+
+An explicit `package_version` or `version` wins over `updateChannel`. If the npm registry is
+temporarily unavailable, the extension reuses an already-installed managed TypeScript 7+ package.
+
+```json
+{
+  "lsp": {
+    "typescript-ls": {
+      "settings": {
+        "updateChannel": "next"
+      }
+    }
+  }
+}
+```
+
+## Legacy settings
+
+The extension previously used the server id `tsgo`. For compatibility, `binary`, `settings`, and
+`initialization_options` each fall back to `lsp.tsgo` when that field is absent under
+`lsp.typescript-ls`.
+
+New configuration should use `lsp.typescript-ls`.
 
 ## Development
 

--- a/extension.toml
+++ b/extension.toml
@@ -17,3 +17,7 @@ name = "TypeScript LS"
 #   javascript -> ScriptKindJS, javascriptreact -> ScriptKindJSX
 language_ids = { TypeScript = "typescript", TSX = "typescriptreact", JavaScript = "javascript", JSX = "javascriptreact" }
 languages = ["TypeScript", "TSX", "JavaScript", "JSX"]
+
+[[capabilities]]
+kind = "npm:install"
+package = "typescript"

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,123 @@
+use std::cell::OnceCell;
+
+use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree, settings::LspSettings};
+
+pub const FALLBACK_LANGUAGE_SERVER_ID: &str = "tsgo";
+
+#[derive(Clone, Copy)]
+pub enum ExtensionSetting {
+    PackageVersion,
+    Version,
+    UpdateChannel,
+    TsdkPath,
+}
+
+impl ExtensionSetting {
+    fn path(self) -> &'static str {
+        match self {
+            Self::PackageVersion => "package_version",
+            Self::Version => "version",
+            Self::UpdateChannel => "updateChannel",
+            Self::TsdkPath => "tsdk.path",
+        }
+    }
+}
+
+pub struct LspSettingsWithFallback<'a> {
+    settings: LspSettings,
+    fallback_settings: OnceCell<Option<LspSettings>>,
+    worktree: &'a Worktree,
+}
+
+impl<'a> LspSettingsWithFallback<'a> {
+    pub fn for_worktree(server_id: &LanguageServerId, worktree: &'a Worktree) -> zed::Result<Self> {
+        LspSettings::for_worktree(server_id.as_ref(), worktree).map(|settings| Self {
+            settings,
+            fallback_settings: OnceCell::new(),
+            worktree,
+        })
+    }
+
+    pub fn get_setting<F, R>(&self, f: F) -> Option<&R>
+    where
+        F: Fn(&LspSettings) -> Option<&R>,
+    {
+        f(&self.settings).or_else(|| {
+            self.fallback_settings
+                .get_or_init(|| {
+                    LspSettings::for_worktree(FALLBACK_LANGUAGE_SERVER_ID, self.worktree).ok()
+                })
+                .as_ref()
+                .and_then(f)
+        })
+    }
+
+    pub fn into_setting<F, R>(self, f: F) -> Option<R>
+    where
+        F: Fn(LspSettings) -> Option<R>,
+    {
+        f(self.settings).or_else(|| {
+            let _ = self.fallback_settings.get_or_init(|| {
+                LspSettings::for_worktree(FALLBACK_LANGUAGE_SERVER_ID, self.worktree).ok()
+            });
+            self.fallback_settings.into_inner().flatten().and_then(f)
+        })
+    }
+}
+
+/// Looks a setting up by its dotted path, accepting both nested and literal
+/// dotted-key forms. The nested form wins when both are set.
+fn setting_value(
+    settings: &Option<zed::serde_json::Value>,
+    setting: ExtensionSetting,
+) -> Option<&zed::serde_json::Value> {
+    let object = settings.as_ref()?.as_object()?;
+    let dotted_path = setting.path();
+
+    let mut parts = dotted_path.split('.');
+    let first = parts.next()?;
+    let nested = object.get(first).and_then(|mut value| {
+        for part in parts {
+            value = value.as_object()?.get(part)?;
+        }
+        Some(value)
+    });
+
+    nested.or_else(|| object.get(dotted_path))
+}
+
+pub fn string_setting(
+    settings: &Option<zed::serde_json::Value>,
+    setting: ExtensionSetting,
+) -> Result<Option<String>> {
+    match setting_value(settings, setting) {
+        None => Ok(None),
+        Some(value) => value.as_str().map(|s| Some(s.to_string())).ok_or_else(|| {
+            format!(
+                "setting `{}` must be a string, got: {value}",
+                setting.path()
+            )
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zed_extension_api::serde_json::json;
+
+    #[test]
+    fn string_setting_nested_wins_and_type_errors() {
+        let settings = Some(json!({
+            "tsdk": {"path": "./nested"},
+            "tsdk.path": "./dotted",
+        }));
+        assert_eq!(
+            string_setting(&settings, ExtensionSetting::TsdkPath).unwrap(),
+            Some("./nested".to_string())
+        );
+
+        let settings = Some(json!({"tsdk": {"path": 5}}));
+        assert!(string_setting(&settings, ExtensionSetting::TsdkPath).is_err());
+    }
+}

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -1,3 +1,5 @@
+mod typescript_package;
+
 use std::cell::OnceCell;
 use std::fs;
 use std::path::PathBuf;
@@ -167,6 +169,67 @@ impl TsGoExtension {
 
         Ok(binary_path.to_string_lossy().to_string())
     }
+
+    fn build_language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<zed::Command> {
+        let lsp_settings =
+            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
+
+        let settings = lsp_settings
+            .as_ref()
+            .and_then(|settings| {
+                settings
+                    .get_setting(|settings| settings.settings.as_ref())
+                    .map(TsGoSettings::from_lsp_settings)
+            })
+            .unwrap_or_default();
+
+        let binary_env = lsp_settings
+            .and_then(|settings| settings.into_setting(|settings| settings.binary))
+            .and_then(|binary| binary.env);
+        let env = server_environment(worktree, binary_env);
+        let arguments = vec!["--lsp".into(), "--stdio".into()];
+
+        if let Some(package_directory) =
+            typescript_package::find_local_typescript_package_dir(worktree)
+        {
+            if let Some(native) =
+                typescript_package::find_native_server_binary(worktree, &package_directory)
+            {
+                return Ok(zed::Command {
+                    command: native,
+                    args: arguments,
+                    env,
+                });
+            }
+
+            let node = worktree
+                .which("node")
+                .map(Ok)
+                .unwrap_or_else(zed::node_binary_path)?;
+            let shim = typescript_package::node_shim_path(worktree, &package_directory)?;
+            return Ok(zed::Command {
+                command: node,
+                args: std::iter::once(shim).chain(arguments).collect(),
+                env,
+            });
+        }
+
+        let executable_path =
+            self.binary_path(language_server_id, settings.package_version.as_deref())?;
+        Ok(zed::Command {
+            command: std::env::current_dir()
+                .map_err(|error| error.to_string())?
+                .join(executable_path)
+                .to_string_lossy()
+                .into_owned(),
+            args: arguments,
+            env,
+        })
+    }
 }
 
 impl zed::Extension for TsGoExtension {
@@ -182,34 +245,22 @@ impl zed::Extension for TsGoExtension {
         language_server_id: &zed_extension_api::LanguageServerId,
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<zed_extension_api::Command> {
-        let lsp_settings =
-            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
-
-        let settings = lsp_settings
-            .as_ref()
-            .and_then(|settings| {
-                settings
-                    .get_setting(|s| s.settings.as_ref())
-                    .map(TsGoSettings::from_lsp_settings)
-            })
-            .unwrap_or_default();
-
-        let env = lsp_settings
-            .and_then(|lsp_settings| lsp_settings.into_setting(|s| s.binary))
-            .and_then(|binary| binary.env);
-
-        let package_version = settings.package_version.as_deref();
-        let executable_path = self.binary_path(language_server_id, package_version)?;
-
-        Ok(zed::Command {
-            command: std::env::current_dir()
-                .map_err(|e| e.to_string())?
-                .join(executable_path)
-                .to_string_lossy()
-                .into_owned(),
-            args: vec!["--lsp".into(), "--stdio".into()],
-            env: env.into_iter().flat_map(|env| env.into_iter()).collect(),
-        })
+        match self.build_language_server_command(language_server_id, worktree) {
+            Ok(command) => {
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::None,
+                );
+                Ok(command)
+            }
+            Err(error) => {
+                zed::set_language_server_installation_status(
+                    language_server_id,
+                    &zed::LanguageServerInstallationStatus::Failed(error.clone()),
+                );
+                Err(error)
+            }
+        }
     }
 
     fn language_server_initialization_options(
@@ -233,6 +284,20 @@ impl zed::Extension for TsGoExtension {
             .unwrap_or_default();
         Ok(Some(settings))
     }
+}
+
+fn server_environment(
+    worktree: &Worktree,
+    binary_env: Option<std::collections::HashMap<String, String>>,
+) -> Vec<(String, String)> {
+    let mut env = worktree.shell_env();
+    if let Some(binary_env) = binary_env {
+        for (key, value) in binary_env {
+            env.retain(|(existing_key, _)| *existing_key != key);
+            env.push((key, value));
+        }
+    }
+    env
 }
 
 struct LspSettingsWithFallback<'a> {

--- a/src/tsgo.rs
+++ b/src/tsgo.rs
@@ -1,231 +1,110 @@
+mod settings;
 mod typescript_package;
 
-use std::cell::OnceCell;
-use std::fs;
-use std::path::PathBuf;
-
-use zed_extension_api::serde_json::Value;
-use zed_extension_api::{self as zed, LanguageServerId, Result, Worktree, settings::LspSettings};
+use settings::{ExtensionSetting, LspSettingsWithFallback};
+use zed_extension_api::{self as zed, LanguageServerId, Result};
 
 struct TsGoExtension {
-    cached_binary_path: Option<String>,
-    cached_version: Option<String>,
-}
-
-const PACKAGE_NAME: &str = "typescript";
-/// LSP ID previously used before TypeScript 7 was released
-const FALLBACK_KEY: &str = "tsgo";
-
-#[derive(Debug, Default)]
-struct TsGoSettings {
-    package_version: Option<String>,
-}
-
-impl TsGoSettings {
-    fn from_lsp_settings(settings: &Value) -> Self {
-        let package_version = settings
-            .get("package_version")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
-
-        Self { package_version }
-    }
+    installed_spec: Option<String>,
 }
 
 impl TsGoExtension {
-    fn get_platform_package_name() -> Result<String> {
-        let (platform, arch) = zed::current_platform();
-
-        let os = match platform {
-            zed::Os::Mac => "darwin",
-            zed::Os::Linux => "linux",
-            zed::Os::Windows => "win32",
-        };
-
-        let arch = match arch {
-            zed::Architecture::Aarch64 => "arm64",
-            zed::Architecture::X86 => {
-                return Err(
-                    "32-bit x86 architecture is not supported. Please use a 64-bit system."
-                        .to_string(),
-                );
-            }
-            zed::Architecture::X8664 => "x64",
-        };
-
-        Ok(format!("@typescript/typescript-{}-{}", os, arch))
-    }
-
-    fn get_native_binary_path() -> Result<PathBuf> {
-        let platform_package = Self::get_platform_package_name()?;
-
-        // Try to find the platform-specific package
-        let package_path = PathBuf::from("node_modules").join(&platform_package);
-
-        if !package_path.exists() {
-            return Err(format!(
-                "Platform package {platform_package} not found at {package_path}. \
-                Make sure the correct platform-specific package is installed \
-                (a pinned package_version must be >= 7.0.0; older typescript versions have no native binary).",
-                package_path = package_path.display()
-            ));
-        }
-
-        let (platform, _) = zed::current_platform();
-        let binary_name = match platform {
-            zed::Os::Windows => "tsc.exe",
-            _ => "tsc",
-        };
-
-        let binary_path = package_path.join("lib").join(binary_name);
-
-        if !binary_path.exists() {
-            return Err(format!(
-                "Native binary not found at {}. The platform package may be corrupted.",
-                binary_path.display()
-            ));
-        }
-
-        Ok(binary_path)
-    }
-
-    fn binary_exists(&self) -> bool {
-        Self::get_native_binary_path().is_ok()
-    }
-
-    fn get_installed_version(&self) -> Option<String> {
-        zed::npm_package_installed_version(PACKAGE_NAME)
-            .ok()
-            .flatten()
-    }
-
-    fn should_install_or_update(&self, target_version: &str) -> bool {
-        if !self.binary_exists() {
-            return true;
-        }
-
-        match self.get_installed_version() {
-            Some(installed_version) => installed_version != target_version,
-            None => true,
-        }
-    }
-
-    fn install_package(
+    /// Resolves the TypeScript 7+ package to run, preferring an explicit
+    /// `tsdk.path`, then a project-local dependency, then a managed install.
+    fn resolve_package_dir(
         &mut self,
-        id: &LanguageServerId,
-        custom_version: Option<&str>,
-    ) -> Result<()> {
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+        extension_settings: &Option<zed::serde_json::Value>,
+    ) -> Result<String> {
+        if let Some(tsdk_path) =
+            settings::string_setting(extension_settings, ExtensionSetting::TsdkPath)?
+        {
+            let directory = typescript_package::tsdk_package_dir(worktree, &tsdk_path);
+            if let Some(version) =
+                typescript_package::typescript_version_from_package_dir(worktree, &directory)
+                    .map_err(|error| {
+                        format!("tsdk.path `{tsdk_path}` resolved to `{directory}`: {error}")
+                    })?
+            {
+                typescript_package::ensure_typescript_7_or_newer(&version)?;
+            }
+            return Ok(directory);
+        }
+
+        if let Some(directory) = typescript_package::find_local_typescript_package_dir(worktree) {
+            return Ok(directory);
+        }
+
+        self.install_managed(language_server_id, extension_settings)
+    }
+
+    fn install_managed(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        extension_settings: &Option<zed::serde_json::Value>,
+    ) -> Result<String> {
         zed::set_language_server_installation_status(
-            id,
+            language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
-        let target_version = match custom_version {
-            Some(version) => version.to_string(),
-            None => zed::npm_package_latest_version(PACKAGE_NAME)?,
-        };
+        let requested = typescript_package::requested_typescript_spec(extension_settings)?;
 
-        if self.should_install_or_update(&target_version) {
-            zed::set_language_server_installation_status(
-                id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-
-            let result = zed::npm_install_package(PACKAGE_NAME, &target_version);
-            if let Err(error) = result
-                && !self.binary_exists()
-            {
-                return Err(error);
-            }
-        }
-
-        let binary_path = Self::get_native_binary_path()
-            .map_err(|e| format!("Failed to locate native binary after installation: {}", e))?;
-
-        // Cache the successful installation
-        self.cached_binary_path = Some(binary_path.to_string_lossy().to_string());
-        self.cached_version = Some(target_version);
-
-        Ok(())
-    }
-
-    fn binary_path(
-        &mut self,
-        id: &LanguageServerId,
-        package_version: Option<&str>,
-    ) -> Result<String> {
-        // Return cached path if we have it and binary still exists
-        if let Some(cached_path) = self.cached_binary_path.as_ref()
-            && fs::metadata(cached_path).is_ok_and(|stat| stat.is_file())
+        if self.installed_spec.as_deref() == Some(requested.install_spec.as_str())
+            && typescript_package::managed_package_is_usable()
         {
-            return Ok(cached_path.clone());
+            return typescript_package::managed_package_dir();
         }
 
-        // Install or update package as needed
-        self.install_package(id, package_version)?;
-
-        let binary_path = Self::get_native_binary_path()
-            .map_err(|e| format!("Failed to locate native binary: {}", e))?;
-
-        Ok(binary_path.to_string_lossy().to_string())
+        let package_directory =
+            typescript_package::install_managed_typescript(language_server_id, &requested)?;
+        self.installed_spec = Some(requested.install_spec);
+        Ok(package_directory)
     }
 
     fn build_language_server_command(
         &mut self,
         language_server_id: &LanguageServerId,
-        worktree: &Worktree,
+        worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
-        let lsp_settings =
-            LspSettingsWithFallback::for_worktree(language_server_id, FALLBACK_KEY, worktree).ok();
-
-        let settings = lsp_settings
+        let lsp_settings = LspSettingsWithFallback::for_worktree(language_server_id, worktree).ok();
+        let extension_settings = lsp_settings
             .as_ref()
-            .and_then(|settings| {
-                settings
-                    .get_setting(|settings| settings.settings.as_ref())
-                    .map(TsGoSettings::from_lsp_settings)
-            })
-            .unwrap_or_default();
-
+            .and_then(|settings| settings.get_setting(|settings| settings.settings.as_ref()))
+            .cloned();
         let binary_env = lsp_settings
             .and_then(|settings| settings.into_setting(|settings| settings.binary))
             .and_then(|binary| binary.env);
-        let env = server_environment(worktree, binary_env);
+
+        let package_directory =
+            self.resolve_package_dir(language_server_id, worktree, &extension_settings)?;
         let arguments = vec!["--lsp".into(), "--stdio".into()];
+        let env = server_environment(worktree, binary_env);
 
-        if let Some(package_directory) =
-            typescript_package::find_local_typescript_package_dir(worktree)
+        // Prefer the native executable directly when the package layout can be
+        // resolved without Node.
+        if let Some(native) =
+            typescript_package::find_native_server_binary(worktree, &package_directory)
         {
-            if let Some(native) =
-                typescript_package::find_native_server_binary(worktree, &package_directory)
-            {
-                return Ok(zed::Command {
-                    command: native,
-                    args: arguments,
-                    env,
-                });
-            }
-
-            let node = worktree
-                .which("node")
-                .map(Ok)
-                .unwrap_or_else(zed::node_binary_path)?;
-            let shim = typescript_package::node_shim_path(worktree, &package_directory)?;
             return Ok(zed::Command {
-                command: node,
-                args: std::iter::once(shim).chain(arguments).collect(),
+                command: native,
+                args: arguments,
                 env,
             });
         }
 
-        let executable_path =
-            self.binary_path(language_server_id, settings.package_version.as_deref())?;
+        // Microsoft's Node launcher handles pnpm and other non-hoisted layouts.
+        let node_command = if let Some(path) = worktree.which("node") {
+            path
+        } else {
+            zed::node_binary_path()?
+        };
+        let shim = typescript_package::node_shim_path(worktree, &package_directory)?;
+        let arguments = std::iter::once(shim).chain(arguments).collect();
+
         Ok(zed::Command {
-            command: std::env::current_dir()
-                .map_err(|error| error.to_string())?
-                .join(executable_path)
-                .to_string_lossy()
-                .into_owned(),
+            command: node_command,
             args: arguments,
             env,
         })
@@ -235,16 +114,15 @@ impl TsGoExtension {
 impl zed::Extension for TsGoExtension {
     fn new() -> Self {
         Self {
-            cached_binary_path: None,
-            cached_version: None,
+            installed_spec: None,
         }
     }
 
     fn language_server_command(
         &mut self,
-        language_server_id: &zed_extension_api::LanguageServerId,
-        worktree: &zed_extension_api::Worktree,
-    ) -> zed_extension_api::Result<zed_extension_api::Command> {
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
         match self.build_language_server_command(language_server_id, worktree) {
             Ok(command) => {
                 zed::set_language_server_installation_status(
@@ -265,85 +143,45 @@ impl zed::Extension for TsGoExtension {
 
     fn language_server_initialization_options(
         &mut self,
-        server_id: &zed_extension_api::LanguageServerId,
-        worktree: &zed_extension_api::Worktree,
-    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
-        let settings = LspSettingsWithFallback::for_worktree(server_id, FALLBACK_KEY, worktree)?
-            .into_setting(|lsp_settings| lsp_settings.initialization_options)
-            .unwrap_or_default();
-        Ok(Some(settings))
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        Ok(
+            LspSettingsWithFallback::for_worktree(language_server_id, worktree)?
+                .into_setting(|settings| settings.initialization_options),
+        )
     }
 
     fn language_server_workspace_configuration(
         &mut self,
-        server_id: &zed_extension_api::LanguageServerId,
-        worktree: &zed_extension_api::Worktree,
-    ) -> zed_extension_api::Result<Option<zed_extension_api::serde_json::Value>> {
-        let settings = LspSettingsWithFallback::for_worktree(server_id, FALLBACK_KEY, worktree)?
-            .into_setting(|lsp_settings| lsp_settings.settings)
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let settings = LspSettingsWithFallback::for_worktree(language_server_id, worktree)?
+            .into_setting(|settings| settings.settings)
             .unwrap_or_default();
         Ok(Some(settings))
     }
 }
 
 fn server_environment(
-    worktree: &Worktree,
+    worktree: &zed::Worktree,
     binary_env: Option<std::collections::HashMap<String, String>>,
 ) -> Vec<(String, String)> {
     let mut env = worktree.shell_env();
+
     if let Some(binary_env) = binary_env {
         for (key, value) in binary_env {
-            env.retain(|(existing_key, _)| *existing_key != key);
-            env.push((key, value));
+            upsert_environment_variable(&mut env, key, value);
         }
     }
+
     env
 }
 
-struct LspSettingsWithFallback<'a> {
-    settings: LspSettings,
-    fallback_id: &'static str,
-    fallback_settings: OnceCell<Option<LspSettings>>,
-    worktree: &'a Worktree,
-}
-
-impl<'a> LspSettingsWithFallback<'a> {
-    fn for_worktree(
-        server_id: &LanguageServerId,
-        fallback_id: &'static str,
-        worktree: &'a Worktree,
-    ) -> zed_extension_api::Result<Self> {
-        LspSettings::for_worktree(server_id.as_ref(), worktree).map(|settings| Self {
-            settings,
-            fallback_id,
-            fallback_settings: OnceCell::new(),
-            worktree,
-        })
-    }
-
-    fn get_setting<F, R>(&self, f: F) -> Option<&R>
-    where
-        F: Fn(&LspSettings) -> Option<&R>,
-    {
-        f(&self.settings).or_else(|| {
-            self.fallback_settings
-                .get_or_init(|| LspSettings::for_worktree(self.fallback_id, self.worktree).ok())
-                .as_ref()
-                .and_then(f)
-        })
-    }
-
-    fn into_setting<F, R>(self, f: F) -> Option<R>
-    where
-        F: Fn(LspSettings) -> Option<R>,
-    {
-        f(self.settings).or_else(|| {
-            let _ = self
-                .fallback_settings
-                .get_or_init(|| LspSettings::for_worktree(self.fallback_id, self.worktree).ok());
-            self.fallback_settings.into_inner().flatten().and_then(f)
-        })
-    }
+fn upsert_environment_variable(env: &mut Vec<(String, String)>, key: String, value: String) {
+    env.retain(|(existing_key, _)| *existing_key != key);
+    env.push((key, value));
 }
 
 zed::register_extension!(TsGoExtension);

--- a/src/typescript_package.rs
+++ b/src/typescript_package.rs
@@ -1,6 +1,159 @@
-use zed_extension_api::{self as zed, Result};
+use crate::settings::{self, ExtensionSetting};
+use zed_extension_api::{self as zed, LanguageServerId, Result};
 
 pub const TYPESCRIPT_PACKAGE: &str = "typescript";
+
+pub struct RequestedTypescriptSpec {
+    pub install_spec: String,
+    pub exact_version: Option<String>,
+}
+
+impl RequestedTypescriptSpec {
+    fn matches_installed(&self, installed: Option<&str>) -> bool {
+        self.exact_version.as_deref().is_some_and(|exact_version| {
+            installed.is_some_and(|installed| installed == exact_version)
+        })
+    }
+}
+
+pub fn requested_typescript_spec(
+    ext_settings: &Option<zed::serde_json::Value>,
+) -> Result<RequestedTypescriptSpec> {
+    let package_version = settings::string_setting(ext_settings, ExtensionSetting::PackageVersion)?;
+    let version = match package_version {
+        Some(version) => Some(version),
+        None => settings::string_setting(ext_settings, ExtensionSetting::Version)?,
+    };
+
+    if let Some(version) = version {
+        let version = version.trim();
+        if version.is_empty() {
+            return Err("TypeScript version setting must not be empty".into());
+        }
+        if !declared_spec_may_resolve_to_typescript_7(version) {
+            return Err(format!(
+                "TypeScript LSP requires a TypeScript 7 or newer version spec, got `{version}`"
+            ));
+        }
+        return Ok(RequestedTypescriptSpec {
+            install_spec: version.to_string(),
+            exact_version: exact_version(version),
+        });
+    }
+
+    let Some(channel) = settings::string_setting(ext_settings, ExtensionSetting::UpdateChannel)?
+    else {
+        return latest_stable_spec();
+    };
+
+    match channel.as_str() {
+        "latest" => latest_stable_spec(),
+        "next" => Ok(RequestedTypescriptSpec {
+            install_spec: "next".to_string(),
+            exact_version: None,
+        }),
+        _ => Err(format!(
+            "unsupported TypeScript update channel `{channel}`; expected `latest` or `next`"
+        )),
+    }
+}
+
+fn latest_stable_spec() -> Result<RequestedTypescriptSpec> {
+    match zed::npm_package_latest_version(TYPESCRIPT_PACKAGE) {
+        Ok(latest) => {
+            ensure_typescript_7_or_newer(&latest)?;
+            Ok(RequestedTypescriptSpec {
+                install_spec: latest.clone(),
+                exact_version: Some(latest),
+            })
+        }
+        Err(error) => match zed::npm_package_installed_version(TYPESCRIPT_PACKAGE) {
+            Ok(Some(installed)) if ensure_typescript_7_or_newer(&installed).is_ok() => {
+                Ok(RequestedTypescriptSpec {
+                    install_spec: installed.clone(),
+                    exact_version: Some(installed),
+                })
+            }
+            _ => Err(error),
+        },
+    }
+}
+
+pub fn install_managed_typescript(
+    language_server_id: &LanguageServerId,
+    requested: &RequestedTypescriptSpec,
+) -> Result<String> {
+    let current = zed::npm_package_installed_version(TYPESCRIPT_PACKAGE)?;
+    let is_tag = requested.exact_version.is_none();
+    let needs_install = is_tag || !requested.matches_installed(current.as_deref());
+
+    if needs_install {
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::Downloading,
+        );
+        zed::npm_install_package(TYPESCRIPT_PACKAGE, &requested.install_spec)?;
+    }
+
+    let installed = zed::npm_package_installed_version(TYPESCRIPT_PACKAGE)?;
+    let installed = installed
+        .as_deref()
+        .ok_or_else(|| "TypeScript was not installed after npm install completed".to_string())?;
+    ensure_typescript_7_or_newer(installed)?;
+
+    managed_package_dir()
+}
+
+pub fn managed_package_dir() -> Result<String> {
+    let path = std::env::current_dir()
+        .map_err(|error| format!("failed to read extension directory: {error}"))?
+        .join("node_modules")
+        .join(TYPESCRIPT_PACKAGE);
+
+    Ok(path.to_string_lossy().into_owned().replace('\\', "/"))
+}
+
+pub fn managed_package_is_usable() -> bool {
+    let Ok(package_dir) = managed_package_dir() else {
+        return false;
+    };
+    let package_json_path = format!("{package_dir}/package.json");
+    let Ok(package_json) = std::fs::read_to_string(&package_json_path) else {
+        return false;
+    };
+    let Ok(version) = typescript_version_from_package_json(&package_json, &package_json_path)
+    else {
+        return false;
+    };
+
+    ensure_typescript_7_or_newer(&version).is_ok()
+        && std::fs::metadata(format!("{package_dir}/bin/tsc"))
+            .is_ok_and(|metadata| metadata.is_file())
+}
+
+/// Normalizes a `tsdk.path` setting into the package root, accepting the
+/// package root, its `lib` directory, `bin`, or a `bin/tsc` launcher.
+pub fn tsdk_package_dir(worktree: &zed::Worktree, tsdk_path: &str) -> String {
+    let trimmed = tsdk_path.trim().trim_end_matches(['/', '\\']);
+    let root = worktree
+        .root_path()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    let base = if trimmed.starts_with('/') || trimmed.starts_with('\\') || trimmed.contains(':') {
+        trimmed.to_string()
+    } else {
+        format!("{root}/{trimmed}")
+    };
+
+    let norm = base.replace('\\', "/");
+    for suffix in ["/bin/tsc.js", "/bin/tsc", "/lib", "/bin"] {
+        if let Some(stripped) = norm.strip_suffix(suffix) {
+            return stripped.to_string();
+        }
+    }
+    norm
+}
 
 /// Finds a usable project-local TypeScript 7+ package by scanning the root
 /// package manifest. npm aliases may use any dependency key, but their target
@@ -132,6 +285,34 @@ fn leading_major(spec: &str) -> Option<u64> {
         .take_while(|character| character.is_ascii_digit())
         .collect();
     (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+/// Reads a package version through the worktree API when the path is in the
+/// project, or through WASI for extension-managed packages. An external
+/// `tsdk.path` cannot be inspected from the extension sandbox and returns
+/// `None`; the package's own launcher will validate it when Zed starts it.
+pub fn typescript_version_from_package_dir(
+    worktree: &zed::Worktree,
+    package_dir: &str,
+) -> Result<Option<String>> {
+    if let Some(relative_directory) = worktree_relative_directory(worktree, package_dir) {
+        let package_json_path = join_relative(&relative_directory, "package.json");
+        return match worktree.read_text_file(&package_json_path) {
+            Ok(content) => {
+                typescript_version_from_package_json(&content, &package_json_path).map(Some)
+            }
+            Err(_) => Ok(None),
+        };
+    }
+
+    let pkg_json = format!("{package_dir}/package.json");
+    match std::fs::read_to_string(&pkg_json) {
+        Ok(content) => typescript_version_from_package_json(&content, &pkg_json).map(Some),
+        Err(error) if path_is_in_extension_work_directory(package_dir) => {
+            Err(format!("failed to read {pkg_json}: {error}"))
+        }
+        Err(_) => Ok(None),
+    }
 }
 
 fn typescript_version_from_package_json(content: &str, path: &str) -> Result<String> {
@@ -278,6 +459,14 @@ fn path_is_in_extension_work_directory(path: &str) -> bool {
     path == current_directory || path.starts_with(&format!("{current_directory}/"))
 }
 
+fn join_relative(directory: &str, path: &str) -> String {
+    if directory.is_empty() {
+        path.to_string()
+    } else {
+        format!("{directory}/{path}")
+    }
+}
+
 pub fn ensure_typescript_7_or_newer(version: &str) -> Result<()> {
     let version_without_prefix = version.strip_prefix('v').unwrap_or(version);
     let major_part = version_without_prefix
@@ -296,6 +485,21 @@ pub fn ensure_typescript_7_or_newer(version: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+fn exact_version(version: &str) -> Option<String> {
+    let version = version.strip_prefix('v').unwrap_or(version).trim();
+    if version.is_empty() || !version.chars().next().unwrap_or(' ').is_ascii_digit() {
+        return None;
+    }
+    let is_exact = version.chars().all(|character| {
+        character.is_ascii_digit()
+            || character == '.'
+            || character == '-'
+            || character == '+'
+            || character.is_ascii_alphabetic()
+    });
+    is_exact.then(|| version.to_string())
 }
 
 #[cfg(test)]
@@ -497,5 +701,51 @@ mod tests {
         assert!(ensure_typescript_7_or_newer("v7.0").is_ok());
         assert!(ensure_typescript_7_or_newer("6.9.9").is_err());
         assert!(ensure_typescript_7_or_newer("foo").is_err());
+    }
+
+    #[test]
+    fn identifies_exact_versions() {
+        assert_eq!(exact_version("7.0.2"), Some("7.0.2".into()));
+        assert_eq!(exact_version("v7.0.2"), Some("7.0.2".into()));
+        assert_eq!(exact_version("7.0.0-beta.1"), Some("7.0.0-beta.1".into()));
+        assert_eq!(exact_version("latest"), None);
+        assert_eq!(exact_version("next"), None);
+        assert_eq!(exact_version("^7"), None);
+    }
+
+    #[test]
+    fn package_version_takes_precedence_over_version_and_channel() {
+        let settings = Some(zed::serde_json::json!({
+            "package_version": "7.0.2",
+            "version": "7.0.1",
+            "updateChannel": "next",
+        }));
+        let requested = requested_typescript_spec(&settings).unwrap();
+        assert_eq!(requested.install_spec, "7.0.2");
+        assert_eq!(requested.exact_version.as_deref(), Some("7.0.2"));
+    }
+
+    #[test]
+    fn accepts_version_alias_and_next_channel() {
+        let settings = Some(zed::serde_json::json!({"version": "^7"}));
+        let requested = requested_typescript_spec(&settings).unwrap();
+        assert_eq!(requested.install_spec, "^7");
+        assert_eq!(requested.exact_version, None);
+
+        let settings = Some(zed::serde_json::json!({"updateChannel": "next"}));
+        let requested = requested_typescript_spec(&settings).unwrap();
+        assert_eq!(requested.install_spec, "next");
+        assert_eq!(requested.exact_version, None);
+    }
+
+    #[test]
+    fn rejects_managed_typescript_6_specs() {
+        for settings in [
+            zed::serde_json::json!({"package_version": "6.0.2"}),
+            zed::serde_json::json!({"version": "^6"}),
+            zed::serde_json::json!({"version": "<7"}),
+        ] {
+            assert!(requested_typescript_spec(&Some(settings)).is_err());
+        }
     }
 }

--- a/src/typescript_package.rs
+++ b/src/typescript_package.rs
@@ -1,0 +1,501 @@
+use zed_extension_api::{self as zed, Result};
+
+pub const TYPESCRIPT_PACKAGE: &str = "typescript";
+
+/// Finds a usable project-local TypeScript 7+ package by scanning the root
+/// package manifest. npm aliases may use any dependency key, but their target
+/// package must be `typescript`.
+pub fn find_local_typescript_package_dir(worktree: &zed::Worktree) -> Option<String> {
+    let content = worktree.read_text_file("package.json").ok()?;
+    let pkg: zed::serde_json::Value = zed::serde_json::from_str(&content).ok()?;
+
+    let root = worktree
+        .root_path()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+
+    find_typescript_dependency(&pkg, &root, |key, _spec, _directory| {
+        let package_json_path = format!("node_modules/{key}/package.json");
+        match worktree.read_text_file(&package_json_path) {
+            Ok(package_json) => {
+                typescript_version_from_package_json(&package_json, &package_json_path)
+                    .and_then(|version| ensure_typescript_7_or_newer(&version))
+                    .is_ok()
+            }
+            // Excluded directories such as node_modules are not always exposed
+            // through Worktree::read_text_file. The manifest declaration was
+            // already checked above, so let Microsoft's launcher resolve it.
+            Err(_) => true,
+        }
+    })
+}
+
+fn find_typescript_dependency(
+    pkg: &zed::serde_json::Value,
+    root: &str,
+    mut package_is_usable: impl FnMut(&str, &str, &str) -> bool,
+) -> Option<String> {
+    for section in ["dependencies", "devDependencies", "peerDependencies"] {
+        let Some(dependencies) = pkg.get(section).and_then(|value| value.as_object()) else {
+            continue;
+        };
+
+        for (key, value) in dependencies {
+            let Some(spec) = value.as_str() else {
+                continue;
+            };
+            if dependency_package_name(key, spec) != Some(TYPESCRIPT_PACKAGE) {
+                continue;
+            }
+            if !declared_spec_may_resolve_to_typescript_7(spec) {
+                continue;
+            }
+
+            let dir = format!("{root}/node_modules/{key}");
+            if package_is_usable(key, spec, &dir) {
+                return Some(dir);
+            }
+        }
+    }
+
+    None
+}
+
+fn dependency_package_name<'a>(key: &'a str, spec: &'a str) -> Option<&'a str> {
+    let spec = spec.trim();
+    let Some(alias) = spec.strip_prefix("npm:") else {
+        return Some(key);
+    };
+
+    let version_separator = if let Some(scoped_alias) = alias.strip_prefix('@') {
+        scoped_alias.rfind('@').map(|position| position + 1)
+    } else {
+        alias.rfind('@')
+    };
+    let package_name = version_separator.map_or(alias, |position| &alias[..position]);
+    (!package_name.is_empty()).then_some(package_name)
+}
+
+/// Rejects declarations that clearly select TypeScript 6 while allowing tags,
+/// broader ranges, and non-registry specs whose installed version cannot be
+/// known from `package.json` alone.
+fn declared_spec_may_resolve_to_typescript_7(spec: &str) -> bool {
+    let spec = dependency_version_spec(spec).trim();
+    if spec.is_empty() {
+        return true;
+    }
+
+    if let Some((_, upper_bound)) = spec.split_once('<') {
+        let upper_bound = upper_bound.trim();
+        let is_inclusive = upper_bound.starts_with('=');
+        let upper_bound = upper_bound.trim_start_matches('=').trim();
+        if leading_major(upper_bound)
+            .is_some_and(|major| major < 7 || (major == 7 && !is_inclusive))
+        {
+            return false;
+        }
+    }
+
+    let bounded_from_major = spec
+        .trim_start_matches(['v', '^', '~', '=', ' '])
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit())
+        && !spec.starts_with('>')
+        && !spec.contains("||");
+    if bounded_from_major {
+        return leading_major(spec).is_none_or(|major| major >= 7);
+    }
+
+    true
+}
+
+fn dependency_version_spec(spec: &str) -> &str {
+    let spec = spec.trim();
+    let Some(alias) = spec.strip_prefix("npm:") else {
+        return spec;
+    };
+
+    let separator = if let Some(scoped_alias) = alias.strip_prefix('@') {
+        scoped_alias.rfind('@').map(|position| position + 1)
+    } else {
+        alias.rfind('@')
+    };
+    separator.map_or("", |position| &alias[position + 1..])
+}
+
+fn leading_major(spec: &str) -> Option<u64> {
+    let digits: String = spec
+        .chars()
+        .skip_while(|character| !character.is_ascii_digit())
+        .take_while(|character| character.is_ascii_digit())
+        .collect();
+    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+}
+
+fn typescript_version_from_package_json(content: &str, path: &str) -> Result<String> {
+    let pkg: zed::serde_json::Value =
+        zed::serde_json::from_str(content).map_err(|error| format!("invalid {path}: {error}"))?;
+    pkg.get("version")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("no version in {path}"))
+}
+
+/// Locates the native `tsc` executable in the platform package next to (or
+/// inside) the resolved TypeScript package. Callers fall back to Microsoft's
+/// Node launcher when an install layout cannot be resolved directly.
+pub fn find_native_server_binary(worktree: &zed::Worktree, package_dir: &str) -> Option<String> {
+    if let Some(relative_directory) = worktree_relative_directory(worktree, package_dir) {
+        let relative_binary = find_worktree_native_server_binary(worktree, &relative_directory)?;
+        return Some(absolute_worktree_path(worktree, &relative_binary));
+    }
+
+    let (platform_package, executable) = platform_package_and_executable()?;
+    let candidates = [
+        format!("{package_dir}/lib/{executable}"),
+        format!("{package_dir}/../{platform_package}/lib/{executable}"),
+        format!("{package_dir}/node_modules/{platform_package}/lib/{executable}"),
+    ];
+
+    candidates
+        .into_iter()
+        .find(|path| std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file()))
+}
+
+fn find_worktree_native_server_binary(
+    worktree: &zed::Worktree,
+    relative_package_directory: &str,
+) -> Option<String> {
+    let (platform_package, executable) = platform_package_and_executable()?;
+    let candidates = [
+        relative_package_directory.to_string(),
+        format!("node_modules/{platform_package}"),
+        format!("{relative_package_directory}/node_modules/{platform_package}"),
+    ];
+
+    candidates.into_iter().find_map(|candidate| {
+        let package_json_path = format!("{candidate}/package.json");
+        let package_json = worktree.read_text_file(&package_json_path).ok()?;
+        let package: zed::serde_json::Value = zed::serde_json::from_str(&package_json).ok()?;
+        let package_name = package.get("name").and_then(|name| name.as_str());
+
+        let is_platform_package =
+            candidate != relative_package_directory || package_name == Some(&platform_package);
+        is_platform_package.then(|| format!("{candidate}/lib/{executable}"))
+    })
+}
+
+fn platform_package_and_executable() -> Option<(String, &'static str)> {
+    let (os, arch) = zed::current_platform();
+    let platform = match os {
+        zed::Os::Mac => "darwin",
+        zed::Os::Linux => "linux",
+        zed::Os::Windows => "win32",
+    };
+    let arch = match arch {
+        zed::Architecture::Aarch64 => "arm64",
+        zed::Architecture::X8664 => "x64",
+        zed::Architecture::X86 => return None,
+    };
+    let exe = match os {
+        zed::Os::Windows => "tsc.exe",
+        _ => "tsc",
+    };
+
+    Some((format!("@typescript/typescript-{platform}-{arch}"), exe))
+}
+
+pub fn node_shim_path(worktree: &zed::Worktree, package_dir: &str) -> Result<String> {
+    let shim = format!("{package_dir}/bin/tsc");
+    let is_in_worktree = worktree_relative_directory(worktree, package_dir).is_some();
+    let exists =
+        is_in_worktree || std::fs::metadata(&shim).is_ok_and(|metadata| metadata.is_file());
+
+    if exists || !path_is_in_extension_work_directory(package_dir) {
+        Ok(shim)
+    } else {
+        Err(format!(
+            "TypeScript package at `{package_dir}` has no native server binary for this platform and no `bin/tsc` launcher"
+        ))
+    }
+}
+
+fn normalized_worktree_root(worktree: &zed::Worktree) -> String {
+    let root = worktree.root_path().replace('\\', "/");
+    if root == "/" {
+        root
+    } else {
+        root.trim_end_matches('/').to_string()
+    }
+}
+
+fn absolute_worktree_path(worktree: &zed::Worktree, relative_path: &str) -> String {
+    let root = normalized_worktree_root(worktree);
+    if root == "/" {
+        format!("/{relative_path}")
+    } else {
+        format!("{root}/{relative_path}")
+    }
+}
+
+fn worktree_relative_directory(worktree: &zed::Worktree, directory: &str) -> Option<String> {
+    let root = normalized_worktree_root(worktree);
+    let directory = directory.replace('\\', "/");
+    if directory == root {
+        return Some(String::new());
+    }
+
+    let prefix = if root == "/" {
+        root
+    } else {
+        format!("{root}/")
+    };
+    if matches!(zed::current_platform().0, zed::Os::Windows) {
+        directory
+            .to_ascii_lowercase()
+            .strip_prefix(&prefix.to_ascii_lowercase())
+            .map(|relative| {
+                let start = directory.len() - relative.len();
+                directory[start..].to_string()
+            })
+    } else {
+        directory.strip_prefix(&prefix).map(|path| path.to_string())
+    }
+}
+
+fn path_is_in_extension_work_directory(path: &str) -> bool {
+    let Ok(current_directory) = std::env::current_dir() else {
+        return false;
+    };
+    let current_directory = current_directory
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    let path = path.replace('\\', "/");
+    path == current_directory || path.starts_with(&format!("{current_directory}/"))
+}
+
+pub fn ensure_typescript_7_or_newer(version: &str) -> Result<()> {
+    let version_without_prefix = version.strip_prefix('v').unwrap_or(version);
+    let major_part = version_without_prefix
+        .split(|character: char| !character.is_ascii_digit())
+        .next()
+        .unwrap_or("");
+    if major_part.is_empty() {
+        return Err(format!("invalid TypeScript version `{version}`"));
+    }
+    let major: u64 = major_part
+        .parse()
+        .map_err(|_| format!("invalid TypeScript version `{version}`"))?;
+    if major < 7 {
+        return Err(format!(
+            "TypeScript LSP requires TypeScript 7 or newer, got `{version}`"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    use super::*;
+
+    struct TestProject {
+        root: PathBuf,
+    }
+
+    impl TestProject {
+        fn new(name: &str) -> Self {
+            static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+
+            let root = std::env::temp_dir().join(format!(
+                "tsgo-{name}-{}-{}",
+                std::process::id(),
+                NEXT_ID.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&root).expect("create test project directory");
+            Self { root }
+        }
+
+        fn add_package(&self, key: &str, version: &str, has_launcher: bool) -> String {
+            let package_dir = self.root.join("node_modules").join(key);
+            std::fs::create_dir_all(&package_dir).expect("create test package directory");
+            std::fs::write(
+                package_dir.join("package.json"),
+                format!(r#"{{"version":"{version}"}}"#),
+            )
+            .expect("write test package.json");
+
+            if has_launcher {
+                let bin_dir = package_dir.join("bin");
+                std::fs::create_dir_all(&bin_dir).expect("create test package bin directory");
+                std::fs::write(bin_dir.join("tsc"), "").expect("write test tsc launcher");
+            }
+
+            package_dir
+                .to_string_lossy()
+                .into_owned()
+                .replace('\\', "/")
+        }
+
+        fn root(&self) -> String {
+            self.root.to_string_lossy().into_owned().replace('\\', "/")
+        }
+    }
+
+    impl Drop for TestProject {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn test_package_is_usable(_key: &str, _spec: &str, directory: &str) -> bool {
+        let package_json_path = format!("{directory}/package.json");
+        let Ok(package_json) = std::fs::read_to_string(&package_json_path) else {
+            return false;
+        };
+        let Ok(version) = typescript_version_from_package_json(&package_json, &package_json_path)
+        else {
+            return false;
+        };
+
+        ensure_typescript_7_or_newer(&version).is_ok()
+            && std::fs::metadata(format!("{directory}/bin/tsc"))
+                .is_ok_and(|metadata| metadata.is_file())
+    }
+
+    #[test]
+    fn parses_dependency_package_names() {
+        let cases = [
+            (("typescript", "^7.0.2"), Some("typescript")),
+            (("typescript", "^8.0.0"), Some("typescript")),
+            (
+                ("@typescript/native", "npm:typescript@^7.0.2"),
+                Some("typescript"),
+            ),
+            (("whatever", " npm:typescript@next "), Some("typescript")),
+            (("foo", "^7.2.0"), Some("foo")),
+            (("foo", "npm:bar@7.0.0"), Some("bar")),
+            (
+                ("typescript", "npm:@typescript/typescript6@^6.0.2"),
+                Some("@typescript/typescript6"),
+            ),
+            (("foo", "npm:@scope/package@next"), Some("@scope/package")),
+            (("foo", "npm:@scope/package"), Some("@scope/package")),
+            (("foo", "npm:"), None),
+        ];
+
+        for ((key, spec), expected) in cases {
+            assert_eq!(dependency_package_name(key, spec), expected);
+        }
+    }
+
+    #[test]
+    fn identifies_declarations_that_can_select_typescript_7() {
+        for spec in [
+            "7.0.2",
+            "^7",
+            "~7.1",
+            "next",
+            "latest",
+            ">=6",
+            ">=6 <8",
+            "<=7",
+            "^6 || ^7",
+            "workspace:^6",
+            "npm:typescript@^7",
+        ] {
+            assert!(
+                declared_spec_may_resolve_to_typescript_7(spec),
+                "{spec} should be accepted"
+            );
+        }
+
+        for spec in [
+            "6.0.2",
+            "^6",
+            "~6.1",
+            "6.x",
+            "<7",
+            "<=6",
+            ">=6 <7",
+            "npm:typescript@^6",
+        ] {
+            assert!(
+                !declared_spec_may_resolve_to_typescript_7(spec),
+                "{spec} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn local_resolution_ignores_unrelated_packages_and_accepts_typescript_8() {
+        let project = TestProject::new("package-identity");
+        project.add_package("foo", "7.2.0", true);
+        let typescript_dir = project.add_package("typescript", "8.0.0", true);
+        let manifest = zed::serde_json::json!({
+            "dependencies": {
+                "foo": "^7.2.0",
+                "typescript": "^8.0.0"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(typescript_dir)
+        );
+    }
+
+    #[test]
+    fn local_resolution_supports_side_by_side_aliases() {
+        let project = TestProject::new("side-by-side-aliases");
+        let native_dir = project.add_package("@typescript/native", "7.0.2", true);
+        project.add_package("typescript", "6.0.2", true);
+        let manifest = zed::serde_json::json!({
+            "devDependencies": {
+                "@typescript/native": "npm:typescript@^7.0.2",
+                "typescript": "npm:@typescript/typescript6@^6.0.2"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(native_dir)
+        );
+    }
+
+    #[test]
+    fn local_resolution_continues_after_an_outdated_alias() {
+        let project = TestProject::new("continue-after-outdated");
+        project.add_package("a-typescript", "6.0.2", true);
+        let usable_dir = project.add_package("z-typescript", "7.0.2", true);
+        let manifest = zed::serde_json::json!({
+            "dependencies": {
+                "a-typescript": "npm:typescript@6.0.2",
+                "z-typescript": "npm:typescript@7.0.2"
+            }
+        });
+
+        assert_eq!(
+            find_typescript_dependency(&manifest, &project.root(), test_package_is_usable),
+            Some(usable_dir)
+        );
+    }
+
+    #[test]
+    fn validates_supported_typescript_versions() {
+        assert!(ensure_typescript_7_or_newer("7.0.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("7.1.0-beta.1").is_ok());
+        assert!(ensure_typescript_7_or_newer("10.0.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("v7.0").is_ok());
+        assert!(ensure_typescript_7_or_newer("6.9.9").is_err());
+        assert!(ensure_typescript_7_or_newer("foo").is_err());
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Stack 2 of 4. Depends on #61.
>
> Until #61 merges, GitHub includes the lower layer in this PR's aggregate diff. The incremental change for this layer is commit `902ba4d`.

## Summary

- Add `tsdk.path` for explicitly selecting a TypeScript package root, `lib` directory, `bin/tsc` launcher, or platform package.
- Add `version` as an alias for the existing `package_version` setting, preserving `package_version` precedence.
- Add `updateChannel` support for the stable `latest` and nightly `next` channels.
- Reject managed TypeScript specifications that can only resolve to TypeScript 6 or older.
- Reuse an installed TypeScript 7+ package when the npm registry is temporarily unavailable.
- Preserve `lsp.tsgo` compatibility independently for `binary`, `settings`, and `initialization_options`.

## Motivation

The managed installer currently supports only one version field and always depends on successful registry resolution. Explicit package selection and predictable channel/version precedence make the adapter usable for pinned, nightly, offline, and non-standard TypeScript installations.

## Resolution order

1. Explicit `tsdk.path`
2. A usable project-local TypeScript 7+ dependency from #61
3. The extension-managed TypeScript package

## Compatibility

- Existing `package_version` configuration continues to work and takes precedence over `version`.
- Existing `lsp.tsgo` settings remain supported field by field.
- The default remains the latest stable TypeScript release.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked --all-targets` (11 tests)
- `markdownlint-cli2 README.md`
- `tombi lint extension.toml Cargo.toml`
- `git diff --check`
